### PR TITLE
Change file read mode from r to rb

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1242,7 +1242,7 @@ uint32_t find_binary_start(range_map<size_t>& rmap) {
 }
 
 file_memory_access get_file_memory_access() {
-    FILE *file = get_file("r");
+    FILE *file = get_file("rb");
     range_map<size_t> rmap;
     uint32_t binary_start;
     try {


### PR DESCRIPTION
This prevents newline translations when picotool tries to read files. Without it, if newline translations occur picotool doesnt read the input files correctly.

I encountered this issue when building picotool with MSVC and using it within WSL.