### PR TITLE
clarify readme and improve an error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ nmake
 
 Picotool is a tool for inspecting RP2040 binaries, and interacting with RP2040 devices when they are in BOOTSEL mode.
 
-Note for full documentation see https://rptl.io/pico-get-started
+Note for full documentation see https://rptl.io/pico-get-started (PDF file).
 
 ```text
 $ picotool help

--- a/main.cpp
+++ b/main.cpp
@@ -2025,7 +2025,7 @@ int main(int argc, char **argv) {
                                 std::cout << bus_device_string(d.first) << description << "\n";
                             }
                         };
-                        printer(dr_vidpid_bootrom_cant_connect, " appears to be a RP2040 device in BOOTSEL mode, but picotool was unable to connect");
+                        printer(dr_vidpid_bootrom_cant_connect, " appears to be a RP2040 device in BOOTSEL mode, but picotool was unable to connect. Try again with sudo.");
                         printer(dr_vidpid_picoprobe, " appears to be a RP2040 PicoProbe device not in BOOTSEL mode.");
                         printer(dr_vidpid_micropython, " appears to be a RP2040 MicroPython device not in BOOTSEL mode.");
                         rc = ERROR_NO_DEVICE;


### PR DESCRIPTION
Hi, 
Just a couple of minor changes to improve readability and to clarify the following error message:
```
st33v@cr4y:~$ picotool info
No accessible RP2040 devices in BOOTSEL mode were found.

but:

Device at bus 1, address 7 appears to be a RP2040 device in BOOTSEL mode, but picotool was unable to connect
```

I added a suggestion to use sudo.