### PR TITLE
Add missing #include <limits> to cli.h

### DIFF
--- a/cli.h
+++ b/cli.h
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <numeric>
 #include <sstream>
+#include <limits>
 
 /**
  * Note this is a hastily hacked together command line parser.


### PR DESCRIPTION
I was getting a compilation error with the version tagged as 1.0.1:
```
FAILED: CMakeFiles/picotool.dir/main.cpp.o 
/usr/bin/x86_64-pc-linux-gnu-g++ -DPICO_BUILD=1 -DPICO_NO_HARDWARE=1 -DPICO_ON_DEVICE=0 -I/usr/include/libusb-1.0 -I/opt/raspberrypi/pico-sdk/src/common/pico_binary_info/include -I/opt/raspberrypi/pico-sdk/src/common/boot_uf2/include -I/opt/raspberrypi/pico-sdk/src/common/boot_picoboot/include -I/opt/raspberrypi/pico-sdk/src/host/pico_platform/include -I/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/picoboot_connection  -march=sandybridge -O2 -pipe -fomit-frame-pointer -std=gnu++14 -MD -MT CMakeFiles/picotool.dir/main.cpp.o -MF CMakeFiles/picotool.dir/main.cpp.o.d -o CMakeFiles/picotool.dir/main.cpp.o -c /var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/main.cpp
In file included from /var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/main.cpp:11:
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h: In member function 'D& cli::matchable_derived<T>::repeatable()':
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h:257:25: error: 'numeric_limits' is not a member of 'std'
  257 |             _max = std::numeric_limits<int>::max();
      |                         ^~~~~~~~~~~~~~
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h:257:40: error: expected primary-expression before 'int'
  257 |             _max = std::numeric_limits<int>::max();
      |                                        ^~~
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h: At global scope:
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h:444:31: error: 'numeric_limits' is not a member of 'std'
  444 |         int _max_value = std::numeric_limits<int>::max();
      |                               ^~~~~~~~~~~~~~
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h:444:46: error: expected primary-expression before 'int'
  444 |         int _max_value = std::numeric_limits<int>::max();
      |                                              ^~~
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h: In lambda function:
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h:408:36: error: 'numeric_limits' is not a member of 'std'
  408 |                 long lvalue = std::numeric_limits<long>::max();
      |                                    ^~~~~~~~~~~~~~
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h:408:51: error: expected primary-expression before 'long'
  408 |                 long lvalue = std::numeric_limits<long>::max();
      |                                                   ^~~~
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h: At global scope:
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h:500:40: error: 'numeric_limits' is not a member of 'std'
  500 |         unsigned int _max_value = std::numeric_limits<unsigned int>::max();
      |                                        ^~~~~~~~~~~~~~
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h:500:55: error: expected primary-expression before 'unsigned'
  500 |         unsigned int _max_value = std::numeric_limits<unsigned int>::max();
      |                                                       ^~~~~~~~
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h: In lambda function:
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h:460:36: error: 'numeric_limits' is not a member of 'std'
  460 |                 long lvalue = std::numeric_limits<long>::max();
      |                                    ^~~~~~~~~~~~~~
/var/tmp/portage/dev-embedded/picotool-1.0.1/work/picotool-1.0.1/cli.h:460:51: error: expected primary-expression before 'long'
  460 |                 long lvalue = std::numeric_limits<long>::max();
      |                                                   ^~~~

```

The fix was to `#include <limits>` in cli.h, so I'm sending this as a PR :)

pico-sdk is v1.1.2 and gcc is:
```
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-pc-linux-gnu/11.1.0/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /var/tmp/portage/sys-devel/gcc-11.1.0/work/gcc-11.1.0/configure --host=x86_64-pc-linux-gnu --build=x86_64-pc-linux-gnu --prefix=/usr --bindir=/usr/x86_64-pc-linux-gnu/gcc-bin/11.1.0 --includedir=/usr/lib/gcc/x86_64-pc-linux-gnu/11.1.0/include --datadir=/usr/share/gcc-data/x86_64-pc-linux-gnu/11.1.0 --mandir=/usr/share/gcc-data/x86_64-pc-linux-gnu/11.1.0/man --infodir=/usr/share/gcc-data/x86_64-pc-linux-gnu/11.1.0/info --with-gxx-include-dir=/usr/lib/gcc/x86_64-pc-linux-gnu/11.1.0/include/g++-v11 --with-python-dir=/share/gcc-data/x86_64-pc-linux-gnu/11.1.0/python --enable-languages=c,c++,fortran --enable-obsolete --enable-secureplt --disable-werror --with-system-zlib --enable-nls --without-included-gettext --enable-checking=release --with-bugurl=https://bugs.gentoo.org/ --with-pkgversion='Gentoo 11.1.0 p1' --disable-esp --enable-libstdcxx-time --with-build-config=bootstrap-lto --enable-shared --enable-threads=posix --enable-__cxa_atexit --enable-clocale=gnu --enable-multilib --with-multilib-list=m32,m64 --disable-fixed-point --enable-targets=all --enable-libgomp --disable-libssp --disable-libada --disable-systemtap --enable-valgrind-annotations --disable-vtable-verify --disable-libvtv --with-zstd --enable-lto --with-isl --disable-isl-version-check --enable-default-pie --enable-default-ssp
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 11.1.0 (Gentoo 11.1.0 p1)
```