### PR TITLE
add runtime destination for make install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,5 +60,5 @@ else()
             picoboot_connection_cxx
             ${LIBUSB_LIBRARIES})
     # allow `make install`
-    install(TARGETS picotool)
+    install(TARGETS picotool RUNTIME DESTINATION bin)
 endif()


### PR DESCRIPTION
I ran into some errors trying to build `picotool` on linux with `cmake`. It looks like there is a missing destination on the `install` command. I added `RUNTIME DESTINATION` based on the [cmake install targets documentation](https://cmake.org/cmake/help/latest/command/install.html#targets).

**`cmake --version` output**
```
cmake --version
cmake version 3.13.4

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

This is the error that I originally encountered when trying to build `picotool`.

**`cmake ..` output**
```
-- The C compiler identification is GNU 8.3.0
-- The CXX compiler identification is GNU 8.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
Using PICO_SDK_PATH from environment ('../../pico-sdk/')
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29") 
-- Checking for module 'libusb-1.0'
--   Found libusb-1.0, version 1.0.22
-- Found LIBUSB: /usr/lib/x86_64-linux-gnu/libusb-1.0.so  
CMake Error at CMakeLists.txt:63 (install):
  install TARGETS given no RUNTIME DESTINATION for executable target
  "picotool".


-- Configuring incomplete, errors occurred!
See also "/home/jeff/github.com/raspberrypi/picotool/build/CMakeFiles/CMakeOutput.log".
```

With my changes, the `cmake ..` error is resolved and `make install` works as expected.

**`cmake ..` and `make install` output with changes**

```
$ cmake ..
-- The C compiler identification is GNU 8.3.0
-- The CXX compiler identification is GNU 8.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
Using PICO_SDK_PATH from environment ('../../pico-sdk/')
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29") 
-- Checking for module 'libusb-1.0'
--   Found libusb-1.0, version 1.0.22
-- Found LIBUSB: /usr/lib/x86_64-linux-gnu/libusb-1.0.so  
-- Configuring done
-- Generating done
-- Build files have been written to: /home/jeff/github.com/raspberrypi/picotool/build
$ sudo make install
Scanning dependencies of target picotool
[ 25%] Building CXX object CMakeFiles/picotool.dir/main.cpp.o
[ 50%] Building CXX object CMakeFiles/picotool.dir/picoboot_connection/picoboot_connection_cxx.cpp.o
[ 75%] Building C object CMakeFiles/picotool.dir/picoboot_connection/picoboot_connection.c.o
[100%] Linking CXX executable picotool
[100%] Built target picotool
Install the project...
-- Install configuration: "Release"
-- Installing: /usr/local/bin/picotool
```