### PR TITLE
Add udev rules for picotool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,27 @@ You need to set PICO_SDK_PATH in the environment, or pass it to cmake.
 
 You also need to install `libusb-1.0`.
 
-Linux/Mac: use your favorite package tool. For example, on Ubuntu:
+### Linux/Mac
+
+Use your favorite package tool. For example, on Ubuntu:
 
 ```console
 sudo apt install build-essential pkg-config libusb-1.0-0-dev
 ```
 
-On Linux you can add udev rules in order to use picotool without sudo:
+On Linux you can add udev rules in order to run picotool without sudo:
 
 ```console
-sudo cp udev/99-picotool.rules /etc/rules/99-picotool.rules
+sudo cp udev/99-picotool.rules /etc/udev/rules.d/
 ```
 
-Windows: download from here https://libusb.info/
+### Windows
 
-If you are on Windows, set LIBUSB_ROOT environment variable to the install directory
+Download libUSB from here https://libusb.info/
 
+set LIBUSB_ROOT environment variable to the install directory.
+
+for Windows with MinGW/WSL:
 ```console
 mkdir build
 cd build
@@ -27,7 +32,7 @@ cmake ..
 make
 ```
 
-for Windows non MinGW/WSL:
+for Windows without MinGW/WSL:
 
 ```console
 mkdir build

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ cd build
 cmake -G "NMake Makefiles" ..
 nmake
 ```
+
+On Linux you can add udev rules in order to use picotool without sudo:
+
+```console
+sudo cp udev/99-picotool.rules /etc/rules/99-picotool.rules
+```
+
 ## Overview
 
 `picotool` is a tool for inspecting RP2040 binaries, and interacting with RP2040 devices when they are in BOOTSEL mode. (As of version 1.1 of `picotool` it is also possible to interact with RP2040 devices that are not in BOOTSEL mode, but are using USB stdio support from the Raspberry Pi Pico SDK by using the `-f` argument of `picotool`).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sudo cp udev/99-picotool.rules /etc/udev/rules.d/
 
 ### Windows
 
-##### For Windows without MinGW/WSL
+##### For Windows without MinGW
 
 Download libUSB from here https://libusb.info/
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Linux/Mac: use your favorite package tool. For example, on Ubuntu:
 sudo apt install build-essential pkg-config libusb-1.0-0-dev
 ```
 
+On Linux you can add udev rules in order to use picotool without sudo:
+
+```console
+sudo cp udev/99-picotool.rules /etc/rules/99-picotool.rules
+```
+
 Windows: download from here https://libusb.info/
 
 If you are on Windows, set LIBUSB_ROOT environment variable to the install directory
@@ -28,12 +34,6 @@ mkdir build
 cd build
 cmake -G "NMake Makefiles" ..
 nmake
-```
-
-On Linux you can add udev rules in order to use picotool without sudo:
-
-```console
-sudo cp udev/99-picotool.rules /etc/rules/99-picotool.rules
 ```
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ You need to set PICO_SDK_PATH in the environment, or pass it to cmake.
 
 You also need to install `libusb-1.0`.
 
-### Linux/Mac
+### Linux / macOS
 
-Use your favorite package tool. For example, on Ubuntu:
+Use your favorite package tool to install dependencies. For example, on Ubuntu:
 
 ```console
 sudo apt install build-essential pkg-config libusb-1.0-0-dev
@@ -47,7 +47,7 @@ make
 
 ##### For Windows with MinGW in MSYS2:
 
-No need to download libusb separately or set LIBUSB_ROOT.
+No need to download libusb separately or set `LIBUSB_ROOT`.
 
 ```console
 pacman -S $MINGW_PACKAGE_PREFIX-{toolchain,cmake,libusb}

--- a/udev/99-picotool.rules
+++ b/udev/99-picotool.rules
@@ -1,0 +1,10 @@
+SUBSYSTEM=="usb", \
+    ATTRS{idVendor}=="2e8a", \
+    ATTRS{idProduct}=="0003", \
+    MODE="660", \
+    GROUP="plugdev"
+SUBSYSTEM=="usb", \
+    ATTRS{idVendor}=="2e8a", \
+    ATTRS{idProduct}=="000a", \
+    MODE="660", \
+    GROUP="plugdev"


### PR DESCRIPTION
I added udev rules for devices in boot and in application mode. Probably not exhaustive.