### PR TITLE
Add error message if --force fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,13 @@ TARGET SELECTION:
         --address <addr>
             Filter devices by USB device address
         -f, --force
-            Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing
-            the command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
+            Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
+            command (unless the command itself is a 'reboot') the device will be rebooted back to application mode. Make sure the device
+            is using USB CDC (USB stdio)
         -F, --force-no-reboot
-            Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing
-            the command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but
-            without the RPI-RP2 drive mounted
+            Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
+            command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without
+            the RPI-RP2 drive mounted. Make sure the device is using USB CDC (USB stdio)
     To target a file
         <filename>
             The file name
@@ -213,12 +214,13 @@ OPTIONS:
         --address <addr>
             Filter devices by USB device address
         -f, --force
-            Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing
-            the command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
+            Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
+            command (unless the command itself is a 'reboot') the device will be rebooted back to application mode. Make sure the device
+            is using USB CDC (USB stdio)
         -F, --force-no-reboot
-            Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing
-            the command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but
-            without the RPI-RP2 drive mounted
+            Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
+            command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without
+            the RPI-RP2 drive mounted. Make sure the device is using USB CDC (USB stdio)
     File to save to
         <filename>
             The file name

--- a/README.md
+++ b/README.md
@@ -216,11 +216,11 @@ OPTIONS:
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode. Make sure the device
-            is using USB CDC (USB stdio)
+            is using USB-CDC (USB stdio)
         -F, --force-no-reboot
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without
-            the RPI-RP2 drive mounted. Make sure the device is using USB CDC (USB stdio)
+            the RPI-RP2 drive mounted. Make sure the device is using USB-CDC (USB stdio)
     File to save to
         <filename>
             The file name

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ TARGET SELECTION:
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode. Make sure the device
-            is using USB CDC (USB stdio)
+            is using USB-CDC (USB stdio)
         -F, --force-no-reboot
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without
-            the RPI-RP2 drive mounted. Make sure the device is using USB CDC (USB stdio)
+            the RPI-RP2 drive mounted. Make sure the device is using USB-CDC (USB stdio)
     To target a file
         <filename>
             The file name

--- a/main.cpp
+++ b/main.cpp
@@ -298,8 +298,8 @@ auto device_selection =
         (option("--address") & integer("addr").min_value(1).max_value(127).set(settings.address)
             .if_missing([] { return "missing address"; })) % "Filter devices by USB device address"
 #if !defined(_WIN32)
-        + option('f', "--force").set(settings.force) % "Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the command (unless the command itself is a 'reboot') the device will be rebooted back to application mode. Make sure the device is using USB CDC (USB stdio)" +
-                option('F', "--force-no-reboot").set(settings.force_no_reboot) % "Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the RPI-RP2 drive mounted. Make sure the device is using USB CDC (USB stdio)"
+        + option('f', "--force").set(settings.force) % "Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the command (unless the command itself is a 'reboot') the device will be rebooted back to application mode. Make sure the device is using USB-CDC (USB stdio)" +
+                option('F', "--force-no-reboot").set(settings.force_no_reboot) % "Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the RPI-RP2 drive mounted. Make sure the device is using USB-CDC (USB stdio)"
 #endif
     ).min(0).doc_non_optional(true);
 

--- a/main.cpp
+++ b/main.cpp
@@ -1571,23 +1571,25 @@ string missing_device_string(bool wasRetry) {
     } else {
         strncpy(b, "No ", bufferLen);
     }
-    char *bufErrorMessage = b + strnlen(b, bufferLen);
+    int currentLength = strnlen(b, bufferLen);
+    char *bufErrorMessage = b + currentLength;
     if (settings.address != -1) {
         if (settings.bus != -1) {
-            snprintf(bufErrorMessage, bufferLen, "accessible RP2040 device in BOOTSEL mode was found at bus %d, address %d.", settings.bus, settings.address);
+            snprintf(bufErrorMessage, bufferLen - currentLength, "accessible RP2040 device in BOOTSEL mode was found at bus %d, address %d.", settings.bus, settings.address);
         } else {
-            snprintf(bufErrorMessage, bufferLen, "accessible RP2040 devices in BOOTSEL mode were found with address %d.", settings.address);
+            snprintf(bufErrorMessage, bufferLen - currentLength, "accessible RP2040 devices in BOOTSEL mode were found with address %d.", settings.address);
         }
     } else {
         if (settings.bus != -1) {
-            snprintf(bufErrorMessage, bufferLen, "accessible RP2040 devices in BOOTSEL mode were found found on bus %d.", settings.bus);
+            snprintf(bufErrorMessage, bufferLen - currentLength, "accessible RP2040 devices in BOOTSEL mode were found found on bus %d.", settings.bus);
         } else {
-            snprintf(bufErrorMessage, bufferLen, "accessible RP2040 devices in BOOTSEL mode were found.");
+            snprintf(bufErrorMessage, bufferLen - currentLength, "accessible RP2040 devices in BOOTSEL mode were found.");
         }
     }
     if (settings.force) {
-        char* bufForceError = b + strnlen(b, bufferLen);
-        snprintf(bufForceError, bufferLen, "\nTo force a device into BOOTSEL mode, make sure the RP2040 is configured to use USB-CDC (USB stdio).");
+        currentLength = strnlen(b, bufferLen);
+        char* bufForceError = b + currentLength;
+        snprintf(bufForceError, bufferLen - currentLength, "\nTo force a device into BOOTSEL mode, make sure the RP2040 is configured to use USB-CDC (USB stdio).");
     }
     return b;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1581,7 +1581,7 @@ string missing_device_string(bool wasRetry) {
         }
     } else {
         if (settings.bus != -1) {
-            snprintf(bufErrorMessage, bufferLen - currentLength, "accessible RP2040 devices in BOOTSEL mode were found found on bus %d.", settings.bus);
+            snprintf(bufErrorMessage, bufferLen - currentLength, "accessible RP2040 devices in BOOTSEL mode were found on bus %d.", settings.bus);
         } else {
             snprintf(bufErrorMessage, bufferLen - currentLength, "accessible RP2040 devices in BOOTSEL mode were found.");
         }


### PR DESCRIPTION
This PR is in response to issue #56.

Using `-f` or `-F` requires the RP2040 to have enabled USB-CDC.
As this isn't immediately obvious this PR adds a short reminder if a load command with a force flag fails.
This also adds a small sentence to the `help load` text.

Running `./picotool load binary.elf -f` with no responding device now outputs:
> No accessible RP2040 devices in BOOTSEL mode were found.
> To force a device into BOOTSEL mode, make sure the RP2040 is configured to use USB-CDC (USB stdio).

The help load text now reads (note the last sentence):
> -f, --force
>             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the  command (unless the command itself is a 'reboot') the device will be rebooted back to application mode. Make sure the device is using USB-CDC (USB stdio)

I've also modified the the printing routine for the error message to use `snprintf` and `strncpy` to avoid potential string-length issues as is good practice.

