### PR TITLE
MSYS2 / MinGW support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ cd build
 cmake -G "NMake Makefiles" ..
 nmake
 ```
+
+Windows with MinGW in MSYS2:
+
+No need to download libusb separately or set LIBUSB_ROOT.
+
+```console
+pacman -S $MINGW_PACKAGE_PREFIX-{toolchain,cmake,libusb}
+mkdir build
+cd build
+MSYS2_ARG_CONV_EXCL=- cmake .. -G"MSYS Makefiles" -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX
+make
+make install DESTDIR=/  # optional
+```
+
 ## Overview
 
 `picotool` is a tool for inspecting RP2040 binaries, and interacting with RP2040 devices when they are in BOOTSEL mode. (As of version 1.1 of `picotool` it is also possible to interact with RP2040 devices that are not in BOOTSEL mode, but are using USB stdio support from the Raspberry Pi Pico SDK by using the `-f` argument of `picotool`).

--- a/cmake/FindLIBUSB.cmake
+++ b/cmake/FindLIBUSB.cmake
@@ -12,12 +12,12 @@ if (LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)
     # in cache already
     set(LIBUSB_FOUND TRUE)
 else (LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)
-    IF (NOT WIN32)
+    IF (NOT MSVC)
         # use pkg-config to get the directories and then use these values
         # in the FIND_PATH() and FIND_LIBRARY() calls
         find_package(PkgConfig)
         pkg_check_modules(PC_LIBUSB libusb-1.0)
-    ENDIF(NOT WIN32)
+    ENDIF ()
     FIND_PATH(LIBUSB_INCLUDE_DIR libusb.h
             HINTS $ENV{LIBUSB_ROOT}/include/libusb-1.0
             PATHS ${PC_LIBUSB_INCLUDEDIR} ${PC_LIBUSB_INCLUDE_DIRS})

--- a/main.cpp
+++ b/main.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
@@ -37,7 +37,7 @@
 #endif
 
 // tsk namespace is polluted on windows
-#ifdef _MSC_VER
+#ifdef _WIN32
 #undef min
 #undef max
 
@@ -2032,7 +2032,7 @@ static int reboot_device(libusb_device *device, bool bootsel, uint disable_mask=
     libusb_device_handle *dev_handle;
     ret = libusb_open(device, &dev_handle);
     if (ret) {
-#if _MSC_VER
+#if _WIN32
         fail(ERROR_USB, "Unable to access device to reboot it; Make sure there is a driver installed via Zadig\n", ret);
 #else
         fail(ERROR_USB, "Unable to access device to reboot it; Use sudo or setup a udev rule\n", ret);


### PR DESCRIPTION
I like to use MSYS2 and its MinGW GCC toolchain for all my open source work; it really is a pleasure because it lets you compile native Windows software from an environment with all the usual Linux utilities, where everything works almost like Linux does.  With MSYS2, you don't have to do a bunch of special work to get your code compiling on Windows.

This pull request makes all the changes necessary to get this building with MinGW in MSYS2.  I don't think it will break anything for users of MSVC, but I haven't tested it with MSVC.
