### PR TITLE
Improve loading speed by 50%

### DIFF
--- a/picoboot_connection/call.s
+++ b/picoboot_connection/call.s
@@ -1,0 +1,17 @@
+.cpu cortex-m0
+.thumb
+  push {r4, lr}
+  mov r4, #20
+  ldrh r0, [r4]      // r0 = function_table
+  ldrh r1, args
+  ldrh r4, [r4, #4]  // r4 = table_lookup
+  blx r4
+  mov r4, r0
+  ldr r0, args + 4
+  ldr r1, args + 8
+  ldr r2, args + 12
+  ldrb r3, args + 16
+  blx r4
+  pop {r4, pc}
+.balign 4, 0
+args:

--- a/picoboot_connection/picoboot_connection.h
+++ b/picoboot_connection/picoboot_connection.h
@@ -39,6 +39,7 @@ int picoboot_enter_cmd_xip(libusb_device_handle *usb_device);
 int picoboot_exit_xip(libusb_device_handle *usb_device);
 int picoboot_reboot(libusb_device_handle *usb_device, uint32_t pc, uint32_t sp, uint32_t delay_ms);
 int picoboot_exec(libusb_device_handle *usb_device, uint32_t addr);
+int picoboot_flash_range_erase(libusb_device_handle *, uint32_t, uint32_t, uint32_t, uint8_t);
 int picoboot_flash_erase(libusb_device_handle *usb_device, uint32_t addr, uint32_t len);
 int picoboot_vector(libusb_device_handle *usb_device, uint32_t addr);
 int picoboot_write(libusb_device_handle *usb_device, uint32_t addr, uint8_t *buffer, uint32_t len);

--- a/picoboot_connection/picoboot_connection_cxx.cpp
+++ b/picoboot_connection/picoboot_connection_cxx.cpp
@@ -81,6 +81,12 @@ void connection::exec(uint32_t addr) {
     wrap_call([&] { return picoboot_exec(device, addr); });
 }
 
+void connection::flash_range_erase(uint32_t addr, uint32_t len,
+    uint32_t block_size, uint8_t block_cmd) {
+    wrap_call([&] { return picoboot_flash_range_erase(device, addr, len,
+      block_size, block_cmd); });
+}
+
 void connection::flash_erase(uint32_t addr, uint32_t len) {
     wrap_call([&] { return picoboot_flash_erase(device, addr, len); });
 }

--- a/picoboot_connection/picoboot_connection_cxx.h
+++ b/picoboot_connection/picoboot_connection_cxx.h
@@ -41,6 +41,7 @@ namespace picoboot {
         void exit_xip();
         void reboot(uint32_t pc, uint32_t sp, uint32_t delay_ms);
         void exec(uint32_t addr);
+        void flash_range_erase(uint32_t addr, uint32_t len, uint32_t block_size, uint8_t block_cmd);
         void flash_erase(uint32_t addr, uint32_t len);
         void vector(uint32_t addr);
         void write(uint32_t addr, uint8_t *buffer, uint32_t len);


### PR DESCRIPTION
The W25Q16JVUXIQ flash chip on the Pico has multiple erase commands that erase different sizes of memory, as documented in the datasheet:

![image](https://user-images.githubusercontent.com/466764/217436546-02d0e701-1740-43f8-9538-dd6508d66138.png)

The current implementation of picotool only uses the 4 KB erase command, which is the least efficient one in terms of bytes per second.

This pull request changes picotool to pick erase sizes based on how much flash is left to load.  The test results below show that loading a 596 KiB UF2 currently takes 4.8 seconds, and with my changes it will only take 3.2 seconds, which means the speed has increased by 50%.  This test was on Windows but I also saw similar results on Linux.

Status quo (commit 03f2812):

```text
$ time ./picotool load --verify rp2-pico-20220618-v1.19.1.uf2
Loading into Flash: [==============================]  100%
Verifying Flash:    [==============================]  100%
  OK

real    0m4.807s
user    0m0.015s
sys     0m0.000s
```

With this PR (commit cdf6228):

```text
$ time ./picotool load --verify rp2-pico-20220618-v1.19.1.uf2
Loading:   [==============================]  100%
Verifying: [==============================]  100%

real    0m3.212s
user    0m0.000s
sys     0m0.000s
```

There is room for further improvement if anyone is interested, because the way the code picks erase sizes is very simple right now.  When it needs to erase 12 KB, it will use three 4 KB commands instead of using a single 32 KB erase command which would be faster.  Also, it would do the erasing using three separate USB commands when one would work.

I haven't looked into how standardized the larger erase commands are and I don't know what set of flash chips picotool is aiming to support, but I thought I'd make the pull request anyway to start the conversation.

The first commit of this pull request contains the speed improvement, and could be merged in or cherry-picked on its own.

The pull request also contains a second commit that further improves things but doesn't have much effect on speed.  The second commit changes the order that things are done so that all verifications are done after all writes.  This is important because the erasing/writing commands might conceivably malfunction and write to parts of the chip they were not supposed to touch, invalidating an earlier verification: the later we can delay verification, the more meaningful it is.  Secondly, the current code fills the screen with numerous progress bars and "OK" messages when you give it a sparse UF2 file that writes to many different regions of flash: it prints "Loading", "Verifying", and "OK" for every region.  Moving all the verifications to the end fixes that.

If anyone is interested, I have a branch with all of my improvements here:  https://github.com/DavidEGrayson/picotool/tree/dev/david/master

