### PR TITLE
Add Serial ID device target filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ PICOTOOL:
     Tool for interacting with a RP2040 device in BOOTSEL mode, or with a RP2040 binary
 
 SYNOPSIS:
-    picotool info [-b] [-p] [-d] [-l] [-a] [--bus <bus>] [--address <addr>] [-f] [-F]
+    picotool info [-b] [-p] [-d] [-l] [-a] [--bus <bus>] [--address <addr>] [--serial <serial>] [-f] [-F]
     picotool info [-b] [-p] [-d] [-l] [-a] <filename> [-t <type>]
-    picotool load [-n] [-N] [-u] [-v] [-x] <filename> [-t <type>] [-o <offset>] [--bus <bus>] [--address <addr>] [-f] [-F]
-    picotool save [-p] [--bus <bus>] [--address <addr>] [-f] [-F] <filename> [-t <type>]
-    picotool save -a [--bus <bus>] [--address <addr>] [-f] [-F] <filename> [-t <type>]
-    picotool save -r <from> <to> [--bus <bus>] [--address <addr>] [-f] [-F] <filename> [-t <type>]
-    picotool verify [--bus <bus>] [--address <addr>] [-f] [-F] <filename> [-t <type>] [-r <from> <to>] [-o <offset>]
-    picotool reboot [-a] [-u] [--bus <bus>] [--address <addr>] [-f] [-F]
+    picotool load [-n] [-N] [-u] [-v] [-x] <filename> [-t <type>] [-o <offset>] [--bus <bus>] [--address <addr>] [--serial <serial>] [-f] [-F]
+    picotool save [-p] [--bus <bus>] [--address <addr>] [--serial <serial>] [-f] [-F] <filename> [-t <type>]
+    picotool save -a [--bus <bus>] [--address <addr>] [--serial <serial>] [-f] [-F] <filename> [-t <type>]
+    picotool save -r <from> <to> [--bus <bus>] [--address <addr>] [--serial <serial>] [-f] [-F] <filename> [-t <type>]
+    picotool verify [--bus <bus>] [--address <addr>] [--serial <serial>] [-f] [-F] <filename> [-t <type>] [-r <from> <to>] [-o <offset>]
+    picotool reboot [-a] [-u] [--bus <bus>] [--address <addr>] [--serial <serial>] [-f] [-F]
     picotool version [-s]
     picotool help [<cmd>]
 
@@ -133,6 +133,8 @@ TARGET SELECTION:
             Filter devices by USB bus number
         --address <addr>
             Filter devices by USB device address
+        --serial <serial>
+            Filter devices by serial id
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing
             the command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -218,7 +220,7 @@ LOAD:
     Load the program / memory range stored in a file onto the device.
 
 SYNOPSIS:
-    picotool load [-n] [-N] [-u] [-v] [-x] <filename> [-t <type>] [-o <offset>] [--bus <bus>] [--address <addr>] [-f] [-F]
+    picotool load [-n] [-N] [-u] [-v] [-x] <filename> [-t <type>] [-o <offset>] [--bus <bus>] [--address <addr>] [--serial <serial>] [-f] [-F]
 
 OPTIONS:
     Post load actions
@@ -249,6 +251,8 @@ OPTIONS:
             Filter devices by USB bus number
         --address <addr>
             Filter devices by USB device address
+        --serial <serial>
+            Filter devices by serial id
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing
             the command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -275,9 +279,9 @@ SAVE:
     Save the program / memory stored in flash on the device to a file.
 
 SYNOPSIS:
-    picotool save [-p] [--bus <bus>] [--address <addr>] [-f] [-F] <filename> [-t <type>]
-    picotool save -a [--bus <bus>] [--address <addr>] [-f] [-F] <filename> [-t <type>]
-    picotool save -r <from> <to> [--bus <bus>] [--address <addr>] [-f] [-F] <filename> [-t <type>]
+    picotool save [-p] [--bus <bus>] [--address <addr>] [--serial <serial>] [-f] [-F] <filename> [-t <type>]
+    picotool save -a [--bus <bus>] [--address <addr>] [--serial <serial>] [-f] [-F] <filename> [-t <type>]
+    picotool save -r <from> <to> [--bus <bus>] [--address <addr>] [--serial <serial>] [-f] [-F] <filename> [-t <type>]
 
 OPTIONS:
     Selection of data to save
@@ -297,6 +301,8 @@ OPTIONS:
             Filter devices by USB bus number
         --address <addr>
             Filter devices by USB device address
+        --serial <serial>
+            Filter devices by serial id
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing
             the command (unless the command itself is a 'reboot') the device will be rebooted back to application mode


### PR DESCRIPTION
This PR is in response to #54 and improves usability of PR #83. This feature can be further improved by integrating the ability to read EEPROM serial number. This functionality is implemented in PR #86.

It adds `--serial <serial>` filter flag to device selection. The serial ID is then compared with string descriptor specified by `iSerial` device configuration option.

As the device in bootloader mode uses different serial than in firmware, changes need to made to filter setting in order to find the device after forced reset. If `--serial` option is specified and the device is forced to reboot by the selected command, filters are adjusted to match the device by combination of bus and port number of the device before the reboot.

As per libusb docs for [libusb_get_port_number](https://libusb.sourceforge.io/api-1.0/group__libusb__dev.html#ga14879a0ea7daccdcddb68852d86c00c4):
> Unless the OS does something funky, or you are hot-plugging USB extension cards, the port number returned by this call is usually guaranteed to be uniquely tied to a physical port, meaning that different devices plugged on the same physical port should return the same port number.

This should be fine for matching immediately after automatic reboot for most cases.

This solution does **NOT** break backward compatibility - functionality and outputs do not change if the flag is not specified.

Usage:
```shell
picotool info --serial ABCDEFG -f
picotool load -x program.u2f --serial ABCDEFG -f
```

For device matching after the reboot, I use internal USB port number filter. This filter can be easily exposed if considered useful for general use. I did not expose it right away to prevent feature creep and CLI option pollution without prior discussion.