### PR TITLE
Use tags to determine file permissions instead of groups

### DIFF
--- a/udev/71-picotool.rules
+++ b/udev/71-picotool.rules
@@ -1,10 +1,10 @@
-SUBSYSTEM=="usb", \
+SUBSYSTEMS=="usb", \
     ATTRS{idVendor}=="2e8a", \
     ATTRS{idProduct}=="0003", \
     MODE="660", \
-    GROUP="plugdev"
-SUBSYSTEM=="usb", \
+    TAG+="uaccess"
+SUBSYSTEMS=="usb", \
     ATTRS{idVendor}=="2e8a", \
     ATTRS{idProduct}=="000a", \
     MODE="660", \
-    GROUP="plugdev"
+    TAG+="uaccess"


### PR DESCRIPTION
 `99-picotool.rules` uses the `plugdev` group which Arch doesn't ship with by default. 

This change removes the `plugdev` group in favor of adding the `uaccess` tag and changes the priority from `99` to `71`. 

Since this is built into `systemd` [by default ](https://github.com/systemd/systemd/blob/main/rules.d/70-uaccess.rules.in) it's distro-agnostic