### PR TITLE
Support rebooting picoprobe CMSIS-DAP v2 devices 

### DIFF
--- a/picoboot_connection/picoboot_connection.c
+++ b/picoboot_connection/picoboot_connection.c
@@ -25,6 +25,7 @@ static bool verbose;
 #define PRODUCT_ID_PICOPROBE   0x0004u
 #define PRODUCT_ID_MICROPYTHON 0x0005u
 #define PRODUCT_ID_STDIO_USB   0x000au
+#define PRODUCT_ID_CMSIS       0x000cu
 
 uint32_t crc32_for_byte(uint32_t remainder) {
     const uint32_t POLYNOMIAL = 0x4C11DB7;
@@ -75,6 +76,8 @@ enum picoboot_device_result picoboot_open_device(libusb_device *device, libusb_d
                 return dr_vidpid_picoprobe;
             case PRODUCT_ID_STDIO_USB:
                 return dr_vidpid_stdio_usb;
+            case PRODUCT_ID_CMSIS:
+                return dr_vidpid_cmsis;
             case PRODUCT_ID_RP2_USBBOOT:
                 break;
             default:

--- a/picoboot_connection/picoboot_connection.h
+++ b/picoboot_connection/picoboot_connection.h
@@ -26,6 +26,7 @@ enum picoboot_device_result {
     dr_vidpid_unknown,
     dr_error,
     dr_vidpid_stdio_usb,
+    dr_vidpid_cmsis,
 };
 
 enum picoboot_device_result picoboot_open_device(libusb_device *device, libusb_device_handle **dev_handle);


### PR DESCRIPTION
This allows for autodetection of PicoProbe instances, and reboots them. 

Requires FarProbe's fork of picoprobe:
https://github.com/FarProbe/picoprobe

https://github.com/raspberrypi/picoprobe/pull/108