### PR TITLE
Accept ELFs with an OS/ABI of ELFOSABI_GNU

### DIFF
--- a/elf/elf_file.cpp
+++ b/elf/elf_file.cpp
@@ -150,7 +150,10 @@ int rp_check_elf_header(const elf32_header &eh) {
     if (eh.common.machine != EM_ARM && eh.common.machine != EM_RISCV) {
         fail(ERROR_FORMAT, "Not an Arm or RISC-V executable");
     }
-    if (eh.common.abi != 0) {
+    // Accept either ELFOSABI_NONE or ELFOSABI_GNU for EI_OSABI. Compilers may
+    // set the OS/ABI field to ELFOSABI_GNU when they use GNU features, such as
+    // the SHF_GNU_RETAIN section flag, but the binary is still compatible.
+    if (eh.common.abi != 0 /* NONE */ && eh.common.abi != 3 /* GNU */) {
         fail(ERROR_INCOMPATIBLE, "Unrecognized ABI");
     }
     // todo amy not sure if this should be expected or not - we have HARD float in clang only for now


### PR DESCRIPTION
RP2 ELF files typically have their EI_OSABI field set to ELFOSABI_NONE. However, when Clang uses GNU extensions, it sets EI_OSABI to ELFOSABI_GNU. The binary is still fully compatible with RP2; ELFOSABI_GNU just indicates that GNU extensions are used in the ELF.

For example, Clang uses the SHF_GNU_RETAIN section flag when compiling a C++17 inline variable with a non-default constructor. This results in an ELF with an EI_OSABI of ELFOSABI_GNU. Picotool currently rejects these ELFs, even though the binary is compatible with the device.