### PR TITLE
fix FreeBSD build

### DIFF
--- a/elf/portable_endian.h
+++ b/elf/portable_endian.h
@@ -52,9 +52,13 @@
 #	define __LITTLE_ENDIAN LITTLE_ENDIAN
 #	define __PDP_ENDIAN    PDP_ENDIAN
 
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__FreeBSD__)
 
 #	include <sys/endian.h>
+
+#elif defined(__NetBSD__) || defined(__DragonFly__)
+
+#   include <sys/endian.h>
 
 #	define be16toh(x) betoh16(x)
 #	define le16toh(x) letoh16(x)


### PR DESCRIPTION
FreeBSD (14.1 RELEASE) compilation fails because the macros in `portable_endian.h` (`be16toh`, `le16toh`, etc) already exist in `sys/endian.h`.

This PR fixes the problem by differentiating FreeBSD from NetBSD/DragonFly and simply including `sys/endian.h` without defining anything else.