### PR TITLE
Replace .dll.a libusb libraries with .a

### DIFF
--- a/cmake/FindLIBUSB.cmake
+++ b/cmake/FindLIBUSB.cmake
@@ -56,5 +56,10 @@ else (LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)
 
     include(FindPackageHandleStandardArgs)
     FIND_PACKAGE_HANDLE_STANDARD_ARGS(LIBUSB DEFAULT_MSG LIBUSB_LIBRARIES LIBUSB_INCLUDE_DIR)
+
+    # Don't use .dll.a libraries, as they require the .dll file to be in the correct location
+    # Replace with .a for static linking instead
+    string(REPLACE ".dll.a" ".a" LIBUSB_LIBRARIES ${LIBUSB_LIBRARIES})
+
     MARK_AS_ADVANCED(LIBUSB_INCLUDE_DIR LIBUSB_LIBRARIES)
 endif (LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)


### PR DESCRIPTION
On Windows, with the latest libusb-1.0.27 downloaded, the `find_library` command returns the `.dll.a` libraries, which refer to the dynamic `.dll` libraries in a separate folder. This means picotool compiles fine, but when run it throws an error that it can't find `libusb-1.0.dll`. It will only run if `libusb-1.0.dll` is in a location Windows searches for `.dll`s, such as the same directory as the executable, or in the path.

Fix this by replacing `.dll.a` with `.a` in the output from `find_library` - this links picotool against the static `libusb-1.0.a` library, so doesn't require any external files.