### PR TITLE
README.md: Improve the MSYS2 and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,32 +66,23 @@ No need to download libusb separately or set `LIBUSB_ROOT`.
 pacman -S $MINGW_PACKAGE_PREFIX-{toolchain,cmake,libusb}
 mkdir build
 cd build
-MSYS2_ARG_CONV_EXCL=- cmake .. -G"MSYS Makefiles" -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX
-make
-make install DESTDIR=/  # optional
+cmake .. -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX
+cmake --build .
 ```
 
 ## Usage by the Raspberry Pi Pico SDK
 
-The Raspberry Pi Pico SDK ([pico-sdk](https://github.com/raspberrypi/pico-sdk)) version 2.0.0 and above, uses `picotool` to do the ELF->UF2 conversion previously handled by the `elf2uf2` tool in the SDK. `picootol` is also used by the SDK for hashing and/or signing binaries.
+The Raspberry Pi Pico SDK ([pico-sdk](https://github.com/raspberrypi/pico-sdk)) version 2.0.0 and above uses `picotool` to do the ELF-to-UF2 conversion previously handled by the `elf2uf2` tool in the SDK. The SDK also uses `picotool` to hash and sign binaries.
 
-Whilst the SDK can download picotool on its own per project, if you have multiple projects or build configurations, it is preferable to install a single copy of `picotool` locally.
+Whilst the SDK can download picotool on its own per project, if you have multiple projects or build configurations, it is preferable to install a single copy of `picotool` locally.  This can be done most simply with `make install` or `cmake --install .`; the SDK will use this installed version by default.
 
-This can be done most simply with `make install`; the SDK will use this installed version by default.
-
-Alternatively you can install in a custom path via:
+Alternatively, you can install to a custom path via:
 
 ```
 cmake -DCMAKE_INSTALL_PREFIX=$MY_INSTALL_DIR -DPICOTOOL_FLAT_INSTALL=1 ..
 ```
 
-In order for the SDK to find `picotool` in this custom path, you  will need to set the `picotool_DIR` variable in your project, either by passing to `-Dpicotool_DIR=$MY_INSTALL_DIR/picotool` to your SDK `cmake` command, or by adding
-
-```CMake
-set(picotool_DIR $MY_INSTALL_DIR/picotool)
-```
-
-to your CMakeLists.txt file.
+In order for the SDK to find `picotool` in this custom path, you will need to set the `picotool_DIR` variable in your project, either by setting the `picotool_DIR` environment variable, by passing `-Dpicotool_DIR=$MY_INSTALL_DIR/picotool` to your `cmake` command, or by adding `set(picotool_DIR $MY_INSTALL_DIR/picotool)` to your CMakeLists.txt file.
 
 ## Overview
 


### PR DESCRIPTION
I originally contributed those MSYS2 instructions, and they used Make.  Now I realize it's better to let MSYS2 use its default CMake generator, which is Ninja.  (You can see the commands got a lot simpler now that we are using Ninja.)

The installation instructions below that point that assumed that Make was being used, because it said `make install`, but we don't want to use Make on MSYS2, so I changed it to `cmake --install .`.

I also noticed that the installation instructions could be improved in other ways.  There was a typo (picootol), some misplaced commas, shorthand (ELF->UF2), and passive voice.  It did not mention the option of setting picotool_DIR as an environment variable (which is very handy), and it was setting picotool_DIR equal to the path to the executable instead of the directory, which seems wrong.  I did test setting the picotool_DIR environment variable equal to a directory, and it works as expected. 