### PR TITLE
Fix compile errors by using clang-x86_64-pc-windows-msvc

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -57,7 +57,7 @@
 #endif
 
 // missing __builtins on windows
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #  include <intrin.h>
 #  define __builtin_popcount __popcnt
 static __forceinline int __builtin_ctz(unsigned x) {

--- a/otp_header_parser/otp_header_parse.cpp
+++ b/otp_header_parser/otp_header_parse.cpp
@@ -15,7 +15,7 @@
 #include "nlohmann/json.hpp"
 
 // missing __builtins on windows
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #  include <intrin.h>
 #  define __builtin_popcount __popcnt
 static __forceinline int __builtin_ctz(unsigned x) {


### PR DESCRIPTION
Fix compile errors when using clang-x86_64-pc-windows-msvc


- Environment

```console
$ clang --version
clang version 18.1.8
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Program Files\LLVM\bin
```

- Error messages

```console
C:/hoge/picotool/otp_header_parser/otp_header_parse.cpp:21:26: error: definition of builtin function '__builtin_ctz'
   21 | static __forceinline int __builtin_ctz(unsigned x) {
      |                          ^
1 error generated.
ninja: build stopped: subcommand failed.
[128/141] Configuring xip_ram_perms_elf.h
ninja: build stopped: subcommand failed.
```

```console
C:/hoge/pico-sdk/build_pico/_deps/picotool-src/main.cpp:63:26: error: definition of builtin function '__builtin_ctz'
   63 | static __forceinline int __builtin_ctz(unsigned x) {
      |                          ^
1 error generated.
ninja: build stopped: subcommand failed.
```
