### PR TITLE
Only show one 'Loading' and one 'Verifying' progress bar when loading

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4256,11 +4256,13 @@ bool load_guts(picoboot::connection con, iostream_memory_access &file_access) {
             }
         }
     }
-    for (auto mem_range : ranges) {
-        enum memory_type type = get_memory_type(mem_range.from, model);
-        // new scope for progress bar
-        {
-            progress_bar bar("Loading into " + memory_names[type] + ": ");
+    size_t total_bytes = 0;
+    for (auto r : ranges) { total_bytes += r.to - r.from; }
+    {
+        progress_bar bar("Loading:   ");
+        size_t loaded_bytes = 0;
+        for (auto mem_range : ranges) {
+            enum memory_type type = get_memory_type(mem_range.from, model);
             uint32_t batch_size = FLASH_SECTOR_ERASE_SIZE;
             bool ok = true;
             vector<uint8_t> file_buf;
@@ -4296,16 +4298,17 @@ bool load_guts(picoboot::connection con, iostream_memory_access &file_access) {
                     raw_access.write_vector(base, file_buf);
                     base += this_batch;
                 }
-                bar.progress(base - mem_range.from, mem_range.to - mem_range.from);
+                bar.progress(base - mem_range.from + loaded_bytes, total_bytes);
             }
+            loaded_bytes += mem_range.to - mem_range.from;
         }
     }
-    for (auto mem_range : ranges) {
-        enum memory_type type = get_memory_type(mem_range.from, model);
-        if (settings.load.verify) {
+    if (settings.load.verify) {
+        progress_bar bar("Verifying: ");
+        size_t verified_bytes = 0;
+        for (auto mem_range : ranges) {
             bool ok = true;
             {
-                progress_bar bar("Verifying " + memory_names[type] + ":    ");
                 uint32_t batch_size = FLASH_SECTOR_ERASE_SIZE;
                 vector<uint8_t> file_buf;
                 vector<uint8_t> device_buf;
@@ -4327,16 +4330,14 @@ bool load_guts(picoboot::connection con, iostream_memory_access &file_access) {
                     }
                     if (ok) {
                         pos = base + this_batch;
+                        bar.progress(pos - mem_range.from + verified_bytes, total_bytes);
                     }
-                    bar.progress(pos - mem_range.from, mem_range.to - mem_range.from);
                 }
             }
-            if (ok) {
-                std::cout << "  OK\n";
-            } else {
-                std::cout << "  FAILED\n";
+            if (!ok) {
                 fail(ERROR_VERIFICATION_FAILED, "The device contents did not match the file");
             }
+            verified_bytes += mem_range.to - mem_range.from;
         }
     }
     if (settings.load.execute) {


### PR DESCRIPTION
This makes the output much shorter and more useful when loading a UF2 file that writes to many different memory ranges, which can happen if it contains a filesystem.  Also, this PR removes the "OK" message that was printed after verification: if the verification finished and there is no error message, that means everything was OK.

This is similar to what I did in my older pull request #66 from 18 months ago for picotool version 1, but that pull request had a bigger scope and was never merged in.

If you want to test this, here is a simple Ruby script I used to generate a fragmented UF2 file for a Pico 2:

```ruby
#!/usr/bin/env ruby
# coding: ASCII-8BIT

output_filename = ARGV.fetch(0)

UF2_FLAG_FAMILY_ID_PRESENT = 0x2000
RP2040_FAMILY_ID = 0xe48bff56
RP2350_ARM_S_FAMILY_ID = 0xe48bff59

FRAGMENT_COUNT = 32
FRAGMENT_SIZE = 4096

block_map = {}
FRAGMENT_COUNT.times do |i|
  (FRAGMENT_SIZE/256).times do |j|
    block_map[i * FRAGMENT_SIZE * 2 + j * 256] = "\xAA" * 256
  end
end

File.open(output_filename, 'wb') do |output|
  block_map.keys.sort.each_with_index do |offset, block_number|
    address = offset + 0x1000_0000
    block = block_map.fetch(offset)
    uf2_block = "UF2\n\x57\x51\x5D\x9E" +
      [UF2_FLAG_FAMILY_ID_PRESENT, address, block.size,
      block_number, block_map.size, RP2350_ARM_S_FAMILY_ID].pack('<LLLLLL') +
      block.ljust(476, "\x00") + "\x30\x6F\xB1\x0A"
    output.write uf2_block
  end
end
```

Picotool output before this pull request:

```text
$ ./picotool.exe load -v ../fragment.uf2
Family ID 'rp2350-arm-s' can be downloaded in absolute space:
  00000000->02000000
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Loading into Flash: [==============================]  100%
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
Verifying Flash:    [==============================]  100%
  OK
```

Picotool output after this pull request:

```text
$ ./picotool.exe load -v ../fragment.uf2
Family ID 'rp2350-arm-s' can be downloaded in absolute space:
  00000000->02000000
Loading:   [==============================]  100%
Verifying: [==============================]  100%
```
