### PR TITLE
Use 4-space indent instead of 8-space indent

### DIFF
--- a/xip_ram_perms/CMakeLists.txt
+++ b/xip_ram_perms/CMakeLists.txt
@@ -1,42 +1,42 @@
 cmake_minimum_required(VERSION 3.12)
 
 if (NOT USE_PRECOMPILED)
-        set(PICO_PLATFORM rp2350-arm-s)
+    set(PICO_PLATFORM rp2350-arm-s)
 
-        # Pull in SDK (must be before project)
-        include(${PICO_SDK_PATH}/external/pico_sdk_import.cmake)
+    # Pull in SDK (must be before project)
+    include(${PICO_SDK_PATH}/external/pico_sdk_import.cmake)
 
-        project(xip_ram_perms C CXX ASM)
-        set(CMAKE_C_STANDARD 11)
-        set(CMAKE_CXX_STANDARD 17)
+    project(xip_ram_perms C CXX ASM)
+    set(CMAKE_C_STANDARD 11)
+    set(CMAKE_CXX_STANDARD 17)
 
-        if (PICO_SDK_VERSION_STRING VERSION_LESS "2.0.0")
-                message(FATAL_ERROR "Raspberry Pi Pico SDK version 2.0.0 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
-        endif()
+    if (PICO_SDK_VERSION_STRING VERSION_LESS "2.0.0")
+        message(FATAL_ERROR "Raspberry Pi Pico SDK version 2.0.0 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
+    endif()
 
-        # Initialize the SDK
-        pico_sdk_init()
+    # Initialize the SDK
+    pico_sdk_init()
 
-        # XIP Ram OTP Perm Setter
-        add_executable(xip_ram_perms
-                set_perms.c
-        )
+    # XIP Ram OTP Perm Setter
+    add_executable(xip_ram_perms
+        set_perms.c
+    )
 
-        target_link_libraries(xip_ram_perms
-                pico_stdlib
-        )
+    target_link_libraries(xip_ram_perms
+        pico_stdlib
+    )
 
-        pico_set_binary_type(xip_ram_perms no_flash)
-        # create linker script to run from 0x20070000
-        file(READ ${PICO_LINKER_SCRIPT_PATH}/memmap_no_flash.ld LINKER_SCRIPT)
-        string(REPLACE "RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 512k" "RAM(rwx) : ORIGIN =  0x13ffc000, LENGTH = 16k" LINKER_SCRIPT "${LINKER_SCRIPT}")
-        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/memmap_xip_ram.ld "${LINKER_SCRIPT}")
-        pico_set_linker_script(xip_ram_perms ${CMAKE_CURRENT_BINARY_DIR}/memmap_xip_ram.ld)
+    pico_set_binary_type(xip_ram_perms no_flash)
+    # create linker script to run from 0x20070000
+    file(READ ${PICO_LINKER_SCRIPT_PATH}/memmap_no_flash.ld LINKER_SCRIPT)
+    string(REPLACE "RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 512k" "RAM(rwx) : ORIGIN =  0x13ffc000, LENGTH = 16k" LINKER_SCRIPT "${LINKER_SCRIPT}")
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/memmap_xip_ram.ld "${LINKER_SCRIPT}")
+    pico_set_linker_script(xip_ram_perms ${CMAKE_CURRENT_BINARY_DIR}/memmap_xip_ram.ld)
 else()
-        project(xip_ram_perms C CXX ASM)
-        message("Using precompiled xip_ram_perms.elf")
-        configure_file(${CMAKE_CURRENT_LIST_DIR}/xip_ram_perms.elf ${CMAKE_CURRENT_BINARY_DIR}/xip_ram_perms.elf COPYONLY)
-        # Use manually specified variables
-        set(NULL ${CMAKE_MAKE_PROGRAM})
-        set(NULL ${PICO_SDK_PATH})
+    project(xip_ram_perms C CXX ASM)
+    message("Using precompiled xip_ram_perms.elf")
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/xip_ram_perms.elf ${CMAKE_CURRENT_BINARY_DIR}/xip_ram_perms.elf COPYONLY)
+    # Use manually specified variables
+    set(NULL ${CMAKE_MAKE_PROGRAM})
+    set(NULL ${PICO_SDK_PATH})
 endif()


### PR DESCRIPTION
For commonality with other CMakeLists.txt files