### PR TITLE
Fix compilation on FreeBSD 13.2 and later.

### DIFF
--- a/elf/portable_endian.h
+++ b/elf/portable_endian.h
@@ -43,27 +43,22 @@
 #	define __LITTLE_ENDIAN LITTLE_ENDIAN
 #	define __PDP_ENDIAN    PDP_ENDIAN
 
-#elif defined(__OpenBSD__)
-
-#	include <endian.h>
-
-#	define __BYTE_ORDER    BYTE_ORDER
-#	define __BIG_ENDIAN    BIG_ENDIAN
-#	define __LITTLE_ENDIAN LITTLE_ENDIAN
-#	define __PDP_ENDIAN    PDP_ENDIAN
-
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
 
 #	include <sys/endian.h>
 
+#ifndef be16toh
 #	define be16toh(x) betoh16(x)
+#endif
+#ifndef le16toh
 #	define le16toh(x) letoh16(x)
-
+#endif
+#ifndef be32toh
 #	define be32toh(x) betoh32(x)
+#endif
+#ifndef le32toh
 #	define le32toh(x) letoh32(x)
-
-#	define be64toh(x) betoh64(x)
-#	define le64toh(x) letoh64(x)
+#endif
 
 #elif defined(__WINDOWS__)
 

--- a/main.cpp
+++ b/main.cpp
@@ -14,7 +14,7 @@
 #include <csignal>
 #include <cstdio>
 #include <regex>
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
 #include <cuchar>
 #endif
 #include <cwchar>


### PR DESCRIPTION
The main change is to `portable_endian.h` which seems to be out-of-date and not maintained upstream.  This change also impacts OpenBSD, but a check of current OpenBSD git repository suggests it is correct there also.
Additionally, `<cuchar>` is excluded in `main.cpp` (as it already was for `__Apple__`); this will probably not be needed in later FreeBSD releases once `<cuchar>` has been picked up from more recent llvm.