### PR TITLE
Fix Bazel build breakages

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,6 +15,13 @@ picotool_binary_data_header(
     out = "xip_ram_perms_elf.h",
 )
 
+# TODO: Make it possible to build the prebuilt from source.
+picotool_binary_data_header(
+    name = "flash_id_bin",
+    src = "//picoboot_flash_id:picoboot_flash_id_prebuilt",
+    out = "flash_id_bin.h",
+)
+
 cc_library(
     name = "xip_ram_perms",
     srcs = ["xip_ram_perms.cpp"],

--- a/bazel/mbedtls.BUILD
+++ b/bazel/mbedtls.BUILD
@@ -9,10 +9,10 @@ cc_library(
             "library/*.h",
         ],
     ),
+    includes = ["include"],
     linkopts = select({
         "@rules_cc//cc/compiler:msvc-cl": ["-DEFAULTLIB:AdvAPI32.Lib"],
         "//conditions:default": [],
     }),
-    includes = ["include"],
     deps = ["@picotool//lib:mbedtls_config"],
 )

--- a/picoboot_connection/BUILD.bazel
+++ b/picoboot_connection/BUILD.bazel
@@ -9,6 +9,7 @@ cc_library(
     hdrs = [
         "picoboot_connection.h",
         "picoboot_connection_cxx.h",
+        "//:flash_id_bin.h",
     ],
     defines = ["HAS_LIBUSB=1"],  # Bazel build always has libusb.
     includes = ["."],
@@ -16,6 +17,7 @@ cc_library(
         "//elf",
         "@libusb",
         "@pico-sdk//src/common/boot_picoboot_headers",
+        "@pico-sdk//src/rp2_common/boot_bootrom_headers",
         "@pico-sdk//src/rp2_common/pico_bootrom:pico_bootrom_headers",
     ],
 )

--- a/picoboot_flash_id/BUILD.bazel
+++ b/picoboot_flash_id/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "picoboot_flash_id_prebuilt",
+    srcs = ["flash_id.bin"],
+)

--- a/picoboot_flash_id/BUILD.bazel
+++ b/picoboot_flash_id/BUILD.bazel
@@ -4,3 +4,5 @@ filegroup(
     name = "picoboot_flash_id_prebuilt",
     srcs = ["flash_id.bin"],
 )
+
+# TODO: Make it possible to build flash_id.bin from source.


### PR DESCRIPTION
Fixes some build breakages related to changes to the Pico SDK structure and the addition of picoboot_flash_id.