### PR TITLE
xip_ram_perms/CMakeLists.txt: unset environment variables CFLAGS, CXX…

### DIFF
--- a/picoboot_flash_id/CMakeLists.txt
+++ b/picoboot_flash_id/CMakeLists.txt
@@ -6,6 +6,14 @@ if (NOT USE_PRECOMPILED)
     # default build type
     set(CMAKE_BUILD_TYPE "MinSizeRel" CACHE STRING "build type")
 
+    # If the user set these environment variables to influence the picotool
+    # build, unset them here so that they do not influence the pico-sdk
+    # build. This is especially required for flags that are not supported
+    # by arm-none-eabi compilers.
+    unset(ENV{CFLAGS})
+    unset(ENV{CXXFLAGS})
+    unset(ENV{LDFLAGS})
+
     include(${PICO_SDK_PATH}/external/pico_sdk_import.cmake)
     project(flash_id C CXX ASM)
     pico_sdk_init()

--- a/xip_ram_perms/CMakeLists.txt
+++ b/xip_ram_perms/CMakeLists.txt
@@ -5,6 +5,14 @@ if (NOT USE_PRECOMPILED)
     
     set(PICO_NO_PICOTOOL 1)
 
+    # If the user set these environment variables to influence the picotool
+    # build, unset them here so that they do not influence the pico-sdk
+    # build. This is especially required for flags that are not supported
+    # by arm-none-eabi compilers.
+    unset(ENV{CFLAGS})
+    unset(ENV{CXXFLAGS})
+    unset(ENV{LDFLAGS})
+
     # Pull in SDK (must be before project)
     include(${PICO_SDK_PATH}/external/pico_sdk_import.cmake)
 


### PR DESCRIPTION
…FLAGS and LDFLAGS

If the user set these environment variables to influence the picotool build, unset them here so that they do not influence the pico-sdk build. This is especially required for flags that are not supported by arm-none-eabi compilers.

As suggested by @will-v-pi in https://github.com/raspberrypi/picotool/issues/139#issuecomment-2338077730