### PR TITLE
Add support for encrypting elfs with section holes within segments

### DIFF
--- a/elf/elf_file.h
+++ b/elf/elf_file.h
@@ -55,6 +55,7 @@ private:
     void read_ph(void);
     void read_sh(void);
     void read_sh_data(void);
+    void read_ph_data(void);
     void read_bytes(unsigned offset, unsigned length, void *dest);
     uint32_t append_section_name(const std::string &sh_name_str);
     void flatten(void);
@@ -65,6 +66,7 @@ private:
     std::vector<elf32_ph_entry> ph_entries;
     std::vector<elf32_sh_entry> sh_entries;
     std::vector<std::vector<uint8_t>> sh_data;
+    std::vector<std::vector<uint8_t>> ph_data;
     bool verbose;
 };
 int rp_check_elf_header(const elf32_header &eh);


### PR DESCRIPTION
While looking at raspberrypi/pico-examples#558 I've discovered that no_flash binaries can end up with a 4 byte gap between the `.text` and `.rodata` sections in the ELF file. This creates a gap between sections in the ELF file, within a single segment.

This PR adds support to `picotool encrypt` for these binaries - without this patch there would be a word of 0s written to the ELF file between the `.text` and `.rodata` sections, rather than the encrypted 0s for that word.

@kilograham Is this also a bug in the SDK linker scripts, as they contain `. = ALIGN(4);`, but the actual alignment of the `.text` and `.rodata` sections in the ELF files produced is 8 bytes? This seems to be what's causing the holey ELF files, and can be prevented with this diff to extend the `.text` section up to the `.rodata` section.
```
--- a/src/rp2_common/pico_crt0/rp2350/memmap_no_flash.ld
+++ b/src/rp2_common/pico_crt0/rp2350/memmap_no_flash.ld
@@ -70,10 +70,10 @@ SECTIONS
         *(.dtors)
 
         *(.eh_frame*)
+        . = ALIGN(8);
     } > RAM
 
     .rodata : {
-        . = ALIGN(4);
         *(.rodata*)
         *(.srodata*)
         . = ALIGN(4);
```