### PR TITLE
Fix segfault when unable to connect to stdio_usb device

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -7582,9 +7582,13 @@ int main(int argc, char **argv) {
     #if defined(__linux__) || defined(__APPLE__)
                             printer(dr_vidpid_bootrom_cant_connect,
                                     " appears to be a RP2040 device in BOOTSEL mode, but picotool was unable to connect. Maybe try 'sudo' or check your permissions.");
+                            printer(dr_vidpid_stdio_usb_cant_connect,
+                                    " appears to be a RP2040 device with a USB serial connection, but picotool was unable to connect. Maybe try 'sudo' or check your permissions.");
     #else
                             printer(dr_vidpid_bootrom_cant_connect,
                                     " appears to be a RP2040 device in BOOTSEL mode, but picotool was unable to connect. You may need to install a driver via Zadig. See \"Getting started with Raspberry Pi Pico\" for more information");
+                            printer(dr_vidpid_stdio_usb_cant_connect,
+                                    " appears to be a RP2040 device with a USB serial connection, but picotool was unable to connect.");
     #endif
                             printer(dr_vidpid_picoprobe,
                                     " appears to be a RP2040 PicoProbe device not in BOOTSEL mode.");

--- a/picoboot_connection/picoboot_connection.c
+++ b/picoboot_connection/picoboot_connection.c
@@ -87,7 +87,11 @@ enum picoboot_device_result picoboot_open_device(libusb_device *device, libusb_d
                 case PRODUCT_ID_PICOPROBE:
                     return dr_vidpid_picoprobe;
                 case PRODUCT_ID_RP2040_STDIO_USB:
+                    *model = rp2040;
+                    res = dr_vidpid_stdio_usb;
+                    break;
                 case PRODUCT_ID_STDIO_USB:
+                    *model = rp2350;
                     res = dr_vidpid_stdio_usb;
                     break;
                 case PRODUCT_ID_RP2040_USBBOOT:

--- a/picoboot_connection/picoboot_connection.c
+++ b/picoboot_connection/picoboot_connection.c
@@ -115,8 +115,8 @@ enum picoboot_device_result picoboot_open_device(libusb_device *device, libusb_d
             if (vid == 0 || strlen(ser) != 0) {
                 // didn't check vid or ser, so treat as unknown
                 return dr_vidpid_unknown;
-            } else if (res != dr_vidpid_unknown) {
-                return res;
+            } else if (res == dr_vidpid_stdio_usb) {
+                return dr_vidpid_stdio_usb_cant_connect;
             } else {
                 return dr_vidpid_bootrom_cant_connect;
             }

--- a/picoboot_connection/picoboot_connection.c
+++ b/picoboot_connection/picoboot_connection.c
@@ -127,7 +127,7 @@ enum picoboot_device_result picoboot_open_device(libusb_device *device, libusb_d
         }
     }
 
-    if (res == dr_vidpid_stdio_usb) {
+    if (!ret && res == dr_vidpid_stdio_usb) {
         if (strlen(ser) != 0) {
             // Check USB serial number
             char ser_str[128];

--- a/picoboot_connection/picoboot_connection.h
+++ b/picoboot_connection/picoboot_connection.h
@@ -38,6 +38,7 @@ enum picoboot_device_result {
     dr_vidpid_unknown,
     dr_error,
     dr_vidpid_stdio_usb,
+    dr_vidpid_stdio_usb_cant_connect,
 };
 
 typedef enum {


### PR DESCRIPTION
This adds `dr_vidpid_stdio_usb_cant_connect` to the `picoboot_device_result` enum, to provide a more useful error when picotool is unable to connect to a device using stdio_usb. The current behaviour was a segfault in this situation, so this now fixes #151

This also builds on #154 to add the correct device to the error message when a stdio_usb device is discovered, rather than just printing RP-series.