### PR TITLE
Fix info and config commands for packaged binaries

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1909,13 +1909,13 @@ struct picoboot_memory_access : public memory_access {
         }
     }
 
-    // note this does not automatically erase flash
+    // note this does not automatically erase flash unless erase is set
     void write(uint32_t address, uint8_t *buffer, unsigned int size) override {
+        vector<uint8_t> write_data; // used when erasing flash
         if (flash == get_memory_type(address, model)) {
             connection.exit_xip();
             if (erase) {
                 // Do automatically erase flash, and make it aligned
-                vector<uint8_t> write_data;
                 // we have to erase in whole pages
                 range aligned_range(address & ~(FLASH_SECTOR_ERASE_SIZE - 1),
                                     ((address + size) & ~(FLASH_SECTOR_ERASE_SIZE - 1)) + FLASH_SECTOR_ERASE_SIZE);

--- a/main.cpp
+++ b/main.cpp
@@ -2897,17 +2897,16 @@ std::unique_ptr<block> find_last_block(memory_access &raw_access, vector<uint8_t
 std::shared_ptr<memory_access> get_bi_access(memory_access &raw_access) {
     vector<uint8_t> bin;
     std::unique_ptr<block> best_block = find_best_block(raw_access, bin);
+    range_map<uint32_t> rmap;
     if (best_block) {
         auto load_map = best_block->get_item<load_map_item>();
         if (load_map != nullptr) {
             // Remap for find_binary_info
-            range_map<uint32_t> rmap;
             build_rmap_load_map(load_map, rmap);
-            return std::make_shared<remapped_memory_access>(raw_access, rmap);
         }
     }
 
-    return std::shared_ptr<memory_access>(&raw_access);
+    return std::make_shared<remapped_memory_access>(raw_access, rmap);
 }
 
 #if HAS_LIBUSB

--- a/main.cpp
+++ b/main.cpp
@@ -2897,8 +2897,6 @@ std::unique_ptr<block> find_last_block(memory_access &raw_access, vector<uint8_t
 std::shared_ptr<memory_access> get_bi_access(memory_access &raw_access) {
     vector<uint8_t> bin;
     std::unique_ptr<block> best_block = find_best_block(raw_access, bin);
-
-    // std::shared_ptr<memory_access> bi_access;
     if (best_block) {
         auto load_map = best_block->get_item<load_map_item>();
         if (load_map != nullptr) {
@@ -3219,7 +3217,7 @@ void info_guts(memory_access &raw_access, void *con) {
                 if (sig_verified != none) {
                     info_pair("signature", sig_verified == passed ? "verified" : "incorrect");
                 }
-            } else if (has_binary_info && get_model(raw_access) == rp2350) {
+            } else if (!best_block && has_binary_info && get_model(raw_access) == rp2350) {
                 fos << "WARNING: Binary on RP2350 device does not contain a block loop - this binary will not boot\n";
             }
         } catch (std::invalid_argument &e) {


### PR DESCRIPTION
Add a remapping based on the load_map when reading binary info from a binary which has one

This fixes reading binary info from packaged binaries (ie SRAM binaries stored in flash)

Also fixes an erroneous warning when using `picotool info -d` on an RP2350 device