### PR TITLE
Add an entry point when signing Arm images

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4684,7 +4684,7 @@ vector<uint8_t> sign_guts_bin(iostream_memory_access in, private_t private_key, 
         std::shared_ptr<entry_point_item> entry_point = new_block.get_item<entry_point_item>();
         if (entry_point == nullptr) {
             std::shared_ptr<vector_table_item> vtor = new_block.get_item<vector_table_item>();
-            uint32_t vtor_loc = 0x10000000;
+            uint32_t vtor_loc = bin_start;
             if (vtor != nullptr) {
                 vtor_loc = vtor->addr;
             }

--- a/main.cpp
+++ b/main.cpp
@@ -4613,9 +4613,14 @@ void sign_guts_elf(elf_file* elf, private_t private_key, public_t public_key) {
         std::shared_ptr<entry_point_item> entry_point = new_block.get_item<entry_point_item>();
         if (entry_point == nullptr) {
             std::shared_ptr<vector_table_item> vtor = new_block.get_item<vector_table_item>();
-            uint32_t vtor_loc = 0x10000000;
+            uint32_t vtor_loc = elf->header().entry < SRAM_START ? 0x10000000 : 0x20000000;
             if (vtor != nullptr) {
                 vtor_loc = vtor->addr;
+            } else {
+                std::shared_ptr<rolling_window_delta_item> rwd = new_block.get_item<rolling_window_delta_item>();
+                if (rwd != nullptr) {
+                    vtor_loc += rwd->addr;
+                }
             }
             auto segment = elf->segment_from_physical_address(vtor_loc);
             auto content = elf->content(*segment);

--- a/main.cpp
+++ b/main.cpp
@@ -4614,19 +4614,19 @@ void sign_guts_elf(elf_file* elf, private_t private_key, public_t public_key) {
         if (entry_point == nullptr) {
             std::shared_ptr<vector_table_item> vtor = new_block.get_item<vector_table_item>();
             uint32_t vtor_loc = 0x10000000;
-            if (elf->header().entry >= SRAM_START) {
-                vtor_loc = 0x20000000;
-            } else if (elf->header().entry >= XIP_SRAM_START_RP2350) {
-                vtor_loc = 0x13ffc000;
-            } else {
-                vtor_loc = 0x10000000;
-            }
             if (vtor != nullptr) {
                 vtor_loc = vtor->addr;
             } else {
-                std::shared_ptr<rolling_window_delta_item> rwd = new_block.get_item<rolling_window_delta_item>();
-                if (rwd != nullptr) {
-                    vtor_loc += rwd->addr;
+                if (elf->header().entry >= SRAM_START) {
+                    vtor_loc = 0x20000000;
+                } else if (elf->header().entry >= XIP_SRAM_START_RP2350) {
+                    vtor_loc = 0x13ffc000;
+                } else {
+                    vtor_loc = 0x10000000;
+                    std::shared_ptr<rolling_window_delta_item> rwd = new_block.get_item<rolling_window_delta_item>();
+                    if (rwd != nullptr) {
+                        vtor_loc += rwd->addr;
+                    }
                 }
             }
             auto segment = elf->segment_from_physical_address(vtor_loc);

--- a/main.cpp
+++ b/main.cpp
@@ -4613,7 +4613,14 @@ void sign_guts_elf(elf_file* elf, private_t private_key, public_t public_key) {
         std::shared_ptr<entry_point_item> entry_point = new_block.get_item<entry_point_item>();
         if (entry_point == nullptr) {
             std::shared_ptr<vector_table_item> vtor = new_block.get_item<vector_table_item>();
-            uint32_t vtor_loc = elf->header().entry < SRAM_START ? 0x10000000 : 0x20000000;
+            uint32_t vtor_loc = 0x10000000;
+            if (elf->header().entry >= SRAM_START) {
+                vtor_loc = 0x20000000;
+            } else if (elf->header().entry >= XIP_SRAM_START_RP2350) {
+                vtor_loc = 0x13ffc000;
+            } else {
+                vtor_loc = 0x10000000;
+            }
             if (vtor != nullptr) {
                 vtor_loc = vtor->addr;
             } else {


### PR DESCRIPTION
Reads the entry point and stack pointer from the vector table, and adds them to the image_def as a new entry_point item. This is only done for signing Arm executable images.

This assumes that the vector table is at 0x10000000 unless a vector_table metadata item is present, which the SDK adds for no_flash binaries, so it should work with all SDK binaries.