### PR TITLE
Always print serial number when unable to find a device with specific serial number

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3581,7 +3581,7 @@ string missing_device_string(bool wasRetry, bool requires_rp2350 = false) {
         }
     } else if (settings.bus != -1) {
         snprintf(buf, buf_len, "accessible %s devices in BOOTSEL mode were found found on bus %d.", device_name, settings.bus);
-    } else if (!settings.ser.empty() && !wasRetry) {
+    } else if (!settings.ser.empty()) {
         snprintf(buf, buf_len, "accessible %s devices in BOOTSEL mode were found found with serial number %s.", device_name, settings.ser.c_str());
     } else {
         snprintf(buf, buf_len, "accessible %s devices in BOOTSEL mode were found.", device_name);


### PR DESCRIPTION
This ensures the error message makes more sense when tracking a device serial number for a reboot.

Previously it would not print the serial number if a device wasn't found after a -f reboot (see https://forums.raspberrypi.com/viewtopic.php?t=378682)