### PR TITLE
Document that the user account needs to be in the plugdev group for udev rules to apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ On Linux you can add udev rules in order to run picotool without sudo:
 sudo cp udev/99-picotool.rules /etc/udev/rules.d/
 ```
 
+You will need to add your account to the plugdev group for the udev rules to apply:
+
+```bash
+sudo usermod -a -G plugdev $USERNAME
+```
+
 ### Windows
 
 ##### For Windows without MinGW


### PR DESCRIPTION
If a user follows the instructions in the README, they may not immediately identify that their user account needs to be in the plugdev group for the udev rules to apply. So be explicit and provide instructions to add the current user's account to the plugdev group.