### PR TITLE
lowercase 'Windows.h' in main.cpp for mingw32 support

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -7496,7 +7496,7 @@ bool reboot_command::execute(device_map &devices) {
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #define VC_EXTRALEAN
-#include <Windows.h>
+#include <windows.h>
 #elif defined(__linux__) || defined(__APPLE__)
 #include <sys/ioctl.h>
 #endif

--- a/picoboot_connection/picoboot_connection.h
+++ b/picoboot_connection/picoboot_connection.h
@@ -81,6 +81,9 @@ int picoboot_flash_id(libusb_device_handle *usb_device, uint64_t *data);
 
 // we require 256 (as this is the page size supported by the device)
 #define LOG2_PAGE_SIZE 8u
+#ifdef PAGE_SIZE
+#undef PAGE_SIZE
+#endif
 #define PAGE_SIZE (1u << LOG2_PAGE_SIZE)
 #define FLASH_SECTOR_ERASE_SIZE 4096u
 


### PR DESCRIPTION
When trying to crosscompile with `ziglang.org` against ming32 libc I noticed the `Windows.h` header is not found.
On windows native it should not make a difference as the filesystem is case-insensitive.