### PR TITLE
Align Saving, Loading and Verifying progress bars

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3922,6 +3922,14 @@ static picoboot::connection get_single_rp2350_bootsel_device_connection(device_m
 
 struct progress_bar {
     explicit progress_bar(string prefix, int width = 30) : prefix(std::move(prefix)), width(width) {
+        // Align all bars with the longest possible prefix string
+        auto longest_mem = std::max_element(
+            std::begin(memory_names), std::end(memory_names),
+            [] (const auto & p1, const auto & p2) {
+                return p1.second.length() < p2.second.length();
+            }
+        );
+        longest_mem_str = longest_mem->second;
         progress(0);
     }
 
@@ -3929,14 +3937,7 @@ struct progress_bar {
         if (_percent != percent) {
             percent = _percent;
             unsigned int len = (width * percent) / 100;
-            // Align all bars with the longest possible prefix string
-            auto longest_mem = std::max_element(
-                std::begin(memory_names), std::end(memory_names),
-                [] (const auto & p1, const auto & p2) {
-                    return p1.second.length() < p2.second.length();
-                }
-            );
-            string extra_space(string("Loading into " + longest_mem->second + ": ").length() - prefix.length(), ' ');
+            string extra_space(string("Loading into " + longest_mem_str + ": ").length() - prefix.length(), ' ');
             std::cout << prefix << extra_space << "[" << string(len, '=') << string(width-len, ' ') << "]  " << std::to_string(percent) << "%\r" << std::flush;
         }
     }
@@ -3952,6 +3953,7 @@ struct progress_bar {
     std::string prefix;
     int percent = -1;
     int width;
+    std::string longest_mem_str;
 };
 
 #if HAS_LIBUSB

--- a/main.cpp
+++ b/main.cpp
@@ -4000,6 +4000,9 @@ bool save_command::execute(device_map &devices) {
             } else {
                 start = settings.from;
                 end = settings.to;
+                // Set offset for verifying
+                settings.offset = start;
+                settings.offset_set = true;
             }
             if (end <= start) {
                 fail(ERROR_ARGS, "Save range is invalid/empty");

--- a/main.cpp
+++ b/main.cpp
@@ -3921,7 +3921,7 @@ static picoboot::connection get_single_rp2350_bootsel_device_connection(device_m
 #endif
 
 struct progress_bar {
-    explicit progress_bar(string prefix, int width = 30) : prefix(std::move(prefix)), width(width) {
+    explicit progress_bar(string new_prefix, int width = 30) : width(width) {
         // Align all bars with the longest possible prefix string
         auto longest_mem = std::max_element(
             std::begin(memory_names), std::end(memory_names),
@@ -3929,7 +3929,8 @@ struct progress_bar {
                 return p1.second.length() < p2.second.length();
             }
         );
-        longest_mem_str = longest_mem->second;
+        string extra_space(string("Loading into " + longest_mem->second + ": ").length() - new_prefix.length(), ' ');
+        prefix = new_prefix + extra_space;
         progress(0);
     }
 
@@ -3937,8 +3938,7 @@ struct progress_bar {
         if (_percent != percent) {
             percent = _percent;
             unsigned int len = (width * percent) / 100;
-            string extra_space(string("Loading into " + longest_mem_str + ": ").length() - prefix.length(), ' ');
-            std::cout << prefix << extra_space << "[" << string(len, '=') << string(width-len, ' ') << "]  " << std::to_string(percent) << "%\r" << std::flush;
+            std::cout << prefix << "[" << string(len, '=') << string(width-len, ' ') << "]  " << std::to_string(percent) << "%\r" << std::flush;
         }
     }
 
@@ -3953,7 +3953,6 @@ struct progress_bar {
     std::string prefix;
     int percent = -1;
     int width;
-    std::string longest_mem_str;
 };
 
 #if HAS_LIBUSB

--- a/main.cpp
+++ b/main.cpp
@@ -97,7 +97,6 @@ typedef map<enum picoboot_device_result,vector<tuple<model_t, void *, void *>>> 
 
 auto memory_names = map<enum memory_type, string>{
         {memory_type::sram, "RAM"},
-        {memory_type::sram_unstriped, "Unstriped RAM"},
         {memory_type::flash, "Flash"},
         {memory_type::xip_sram, "XIP RAM"},
         {memory_type::rom, "ROM"}
@@ -4037,7 +4036,7 @@ bool save_command::execute(device_map &devices) {
     model_t model = get_model(raw_access);
     enum memory_type t1 = get_memory_type(start , model);
     enum memory_type t2 = get_memory_type(end, model);
-    if (t1 == invalid || t1 != t2) {
+    if (t1 != t2 || t1 == invalid || t1 == sram_unstriped) {
         fail(ERROR_NOT_POSSIBLE, "Save range crosses unmapped memory");
     }
     uint32_t size = end - start;
@@ -4272,7 +4271,7 @@ bool load_guts(picoboot::connection con, iostream_memory_access &file_access) {
     for (auto mem_range : ranges) {
         enum memory_type t1 = get_memory_type(mem_range.from, model);
         enum memory_type t2 = get_memory_type(mem_range.to, model);
-        if (t1 != t2 || t1 == invalid || t1 == rom) {
+        if (t1 != t2 || t1 == invalid || t1 == rom || t1 == sram_unstriped) {
             fail(ERROR_FORMAT, "File to load contained an invalid memory range 0x%08x-0x%08x", mem_range.from,
                  mem_range.to);
         }
@@ -4934,7 +4933,7 @@ bool verify_command::execute(device_map &devices) {
         for (auto mem_range : ranges) {
             enum memory_type t1 = get_memory_type(mem_range.from, model);
             enum memory_type t2 = get_memory_type(mem_range.to, model);
-            if (t1 != t2 || t1 == invalid) {
+            if (t1 != t2 || t1 == invalid || t1 == sram_unstriped) {
                 fail(ERROR_NOT_POSSIBLE, "invalid memory range for verification %08x-%08x", mem_range.from, mem_range.to);
             } else {
                 bool ok = true;


### PR DESCRIPTION
Align all the Saving, Loading and Verifying progress bars, by placing them at the longest possible prefix. Also prevent saving/loading from the RP2040 unstriped SRAM, as that returns an error from the device, and would increase the length of the longest possible prefix.

This changes the output from
```
$ picotool save -v flash.bin -r 0x10000000 0x10040000
Saving file: [==============================]  100%
Wrote 262144 bytes to flash.bin
Verifying Flash:    [==============================]  100%
  OK
$ picotool load -v flash.bin 
Loading into Flash: [==============================]  100%
Verifying Flash:    [==============================]  100%
  OK
```
to
```
$ picotool save -v flash.bin -r 0x10000000 0x10040000
Saving file:          [==============================]  100%
Wrote 262144 bytes to flash.bin
Verifying Flash:      [==============================]  100%
  OK
$ picotool load -v flash.bin 
Loading into Flash:   [==============================]  100%
Verifying Flash:      [==============================]  100%
  OK
```