### PR TITLE
List field desciptions if field is matching

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -426,6 +426,7 @@ struct _settings {
         std::vector<uint32_t> pages;
         bool list_pages = false;
         bool list_no_descriptions = false;
+        bool list_field_descriptions = false;
         std::vector<std::string> selectors;
         uint32_t row = 0;
         std::vector<std::string> extra_files;
@@ -952,6 +953,7 @@ struct otp_list_command : public cmd {
                 (
                         option('p', "--pages").set(settings.otp.list_pages) % "Show page number/page row number" +
                         option('n', "--no-descriptions").set(settings.otp.list_no_descriptions) % "Don't show descriptions" +
+                        option('f', "--field-descriptions").set(settings.otp.list_field_descriptions) % "Show all field descriptions" +
                         (option('i', "--include") & value("filename").add_to(settings.otp.extra_files)).min(0).max(1) % "Include extra otp definition" + // todo more than 1
                         (value("selector").add_to(settings.otp.selectors) %
                          "The row/field selector, each of which can select a whole row:\n\n" \
@@ -6962,6 +6964,15 @@ bool otp_list_command::execute(device_map &devices) {
                     fos << " (bit " << low << ")\n";
                 } else {
                     fos << " (bits " << low << "-" << high << ")\n";
+                }
+                const otp_field *field = m.field;
+                if ((m.field || settings.otp.list_field_descriptions) && !settings.otp.list_no_descriptions && !f.description.empty()) {
+                    // Only print field descriptors if matching a field, or if list_field_descriptions is set
+                    fos.first_column(indent0);
+                    fos.hanging_indent(0);
+                    fos << "\"" << f.description << "\"";
+                    fos.first_column(0);
+                    fos << "\n";
                 }
             }
         }

--- a/main.cpp
+++ b/main.cpp
@@ -6965,7 +6965,6 @@ bool otp_list_command::execute(device_map &devices) {
                 } else {
                     fos << " (bits " << low << "-" << high << ")\n";
                 }
-                const otp_field *field = m.field;
                 if ((m.field || settings.otp.list_field_descriptions) && !settings.otp.list_no_descriptions && !f.description.empty()) {
                     // Only print field descriptors if matching a field, or if list_field_descriptions is set
                     fos.first_column(indent0);


### PR DESCRIPTION
With `otp list`, show field descriptions if a field is matched, or if the `-f` flag is set:

```bash
$ picotool otp list crit1
ROW 0x0040: OTP_DATA_CRIT1
        "Page 1 critical boot flags (RBIT-8)"
    field GLITCH_DETECTOR_SENS (bits 5-6)
    field GLITCH_DETECTOR_ENABLE (bit 4)
    field BOOT_ARCH (bit 3)
    field DEBUG_DISABLE (bit 2)
    field SECURE_DEBUG_DISABLE (bit 1)
    field SECURE_BOOT_ENABLE (bit 0)
```

```bash
$ picotool otp list crit1 -f
ROW 0x0040: OTP_DATA_CRIT1
        "Page 1 critical boot flags (RBIT-8)"
    field GLITCH_DETECTOR_SENS (bits 5-6)
        "Increase the sensitivity of the glitch detectors from their default."
    field GLITCH_DETECTOR_ENABLE (bit 4)
        "Arm the glitch detectors to reset the system if an abnormal clock/power event is observed."
    field BOOT_ARCH (bit 3)
        "Set the default boot architecture, 0=ARM 1=RISC-V. Ignored if ARM_DISABLE, RISCV_DISABLE or SECURE_BOOT_ENABLE is set."
    field DEBUG_DISABLE (bit 2)
        "Disable all debug access"
    field SECURE_DEBUG_DISABLE (bit 1)
        "Disable Secure debug access"
    field SECURE_BOOT_ENABLE (bit 0)
        "Enable boot signature enforcement, and permanently disable the RISC-V cores."
```

```bash
$ picotool otp list crit1.boot_arch
ROW 0x0040: OTP_DATA_CRIT1
        "Page 1 critical boot flags (RBIT-8)"
    field BOOT_ARCH (bit 3)
        "Set the default boot architecture, 0=ARM 1=RISC-V. Ignored if ARM_DISABLE, RISCV_DISABLE or SECURE_BOOT_ENABLE is set."
```

Fixes #134 