### PR TITLE
Allow using thirdparty VID for reboot interface

### DIFF
--- a/picoboot_connection/BUILD.bazel
+++ b/picoboot_connection/BUILD.bazel
@@ -19,5 +19,6 @@ cc_library(
         "@pico-sdk//src/common/boot_picoboot_headers",
         "@pico-sdk//src/rp2_common/boot_bootrom_headers",
         "@pico-sdk//src/rp2_common/pico_bootrom:pico_bootrom_headers",
+        "@pico-sdk//src/rp2_common/pico_stdio_usb:reset_interface_headers",
     ],
 )

--- a/picoboot_connection/picoboot_connection.c
+++ b/picoboot_connection/picoboot_connection.c
@@ -11,6 +11,7 @@
 
 #include "picoboot_connection.h"
 #include "boot/bootrom_constants.h"
+#include "pico/stdio_usb/reset_interface.h"
 
 #if ENABLE_DEBUG_LOG
 #include <stdio.h>
@@ -139,6 +140,17 @@ enum picoboot_device_result picoboot_open_device(libusb_device *device, libusb_d
             }
         } else {
             return res;
+        }
+    }
+
+    // Runtime reset interface with thirdparty VID
+    if (!ret) {
+        for (int i = 0; i < config->bNumInterfaces; i++) {
+            if (config->interface[i].altsetting[0].bInterfaceClass == 0xff &&
+                config->interface[i].altsetting[0].bInterfaceSubClass == RESET_INTERFACE_SUBCLASS &&
+                config->interface[i].altsetting[0].bInterfaceProtocol == RESET_INTERFACE_PROTOCOL) {
+                return dr_vidpid_stdio_usb;
+            }
         }
     }
 


### PR DESCRIPTION
I'm implementing the reboot interface for a custom device. But I'm not using the Raspberry PI vendor ID.
There's no way currently to allow those third party devices to reboot.

With this change I can reboot my device from application firmware into bootloader with:

```
picotool reboot --vid 0x32ac --pid 0x001f -f -u
```