### PR TITLE
Fix macOS CI builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install cmake libusb pkg-config ninja
+          brew install libusb ninja
           brew install --cask gcc-arm-embedded
 
       - name: Install dependencies (Linux)


### PR DESCRIPTION
By removing cmake and pkg-config from the dependencies

Apparently they're already included: https://github.com/actions/runner-images/blob/macos-14-arm64/20241119.505/images/macos/macos-14-arm64-Readme.md

And they were causing warnings / errors in the GitHub CI macOS builds:
```
Warning: Treating cmake as a formula. For the cask, use homebrew/cask/cmake or specify the `--cask` flag. To silence this message, use the `--formula` flag.
Warning: cmake 3.31.0 is already installed and up-to-date.
To reinstall 3.31.0, run:
  brew reinstall cmake

==> Pouring pkgconf--2.3.0_1.arm64_sonoma.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /opt/homebrew
Could not symlink bin/pkg-config
Target /opt/homebrew/bin/pkg-config
is a symlink belonging to pkg-config@0.29.2. You can unlink it:
  brew unlink pkg-config@0.29.2

To force the link and overwrite all conflicting files:
  brew link --overwrite pkgconf

To list all files that would be deleted:
  brew link --overwrite pkgconf --dry-run

Possible conflicting files are:
/opt/homebrew/bin/pkg-config -> /opt/homebrew/Cellar/pkg-config@0.[29](https://github.com/FrameworkComputer/picotool/actions/runs/11924333330/job/33234474972#step:5:30).2/0.29.2_3/bin/pkg-config
/opt/homebrew/share/aclocal/pkg.m4 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/aclocal/pkg.m4
/opt/homebrew/share/man/man1/pkg-config.1 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/man/man1/pkg-config.1
```

(see also https://github.com/raspberrypi/pico-sdk/pull/2050 - I guess GitHub must have been doing a bunch of updates to their CI infrastructure recently!)