### PR TITLE
Preemptively update Bazel dep on Pico SDK for 2.1.0 release

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ module(
 )
 
 bazel_dep(name = "rules_libusb", version = "0.1.0-rc1")
-bazel_dep(name = "pico-sdk", version = "2.0.0")
+bazel_dep(name = "pico-sdk", version = "2.1.0")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
 bazel_dep(name = "rules_python", version = "0.22.1")


### PR DESCRIPTION
While pico-sdk@2.1.0 will be backwards compatible with picotool@2.0.0, picotool@2.1.0 will require pico-sdk@2.1.0 to properly build.