### PR TITLE
Add caching of flash reads

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1980,7 +1980,6 @@ struct picoboot_memory_access : public memory_access {
     void write(uint32_t address, uint8_t *buffer, unsigned int size) override {
         vector<uint8_t> write_data; // used when erasing flash
         if (flash == get_memory_type(address, model)) {
-            clear_cache(); // clear entire flash cache on any write, to be safe
             connection.exit_xip();
             if (erase) {
                 // Do automatically erase flash, and make it aligned
@@ -2014,6 +2013,7 @@ struct picoboot_memory_access : public memory_access {
         }
         if (is_transfer_aligned(address, model) && is_transfer_aligned(address + size, model)) {
             connection.write(address, (uint8_t *) buffer, size);
+            clear_cache(); // clear entire flash cache after any write, to be safe
         } else {
             // for write, we must be correctly sized/aligned in 256 byte chunks
             std::stringstream sstream;


### PR DESCRIPTION
Add caching of flash reads from the device (#183), as the current metadata scans read from the same regions multiple times.

This provides a speedup to `picotool info -a` on my 4 partition device from 5.7s to 1.6s, and speeds up `picotool info` from 3.8s to 1.4s, so provides a good performance boost.

Gets fully invalidated on any writes, to minimise complexity, as the only read & write command is `picotool config` which wouldn't benefit from caching anyway. Also gets invalidated when using `picotool save --verify`, so you're not just verifying the cached data.