### PR TITLE
Add verbose output from picotool uf2 convert

### DIFF
--- a/elf2uf2/elf2uf2.h
+++ b/elf2uf2/elf2uf2.h
@@ -21,8 +21,8 @@
 
 
 bool check_abs_block(uf2_block block);
-int bin2uf2(std::shared_ptr<std::iostream> in, std::shared_ptr<std::iostream> out, uint32_t address, uint32_t family_id, uint32_t abs_block_loc=0);
-int elf2uf2(std::shared_ptr<std::iostream> in, std::shared_ptr<std::iostream> out, uint32_t family_id, uint32_t package_addr=0, uint32_t abs_block_loc=0);
+int bin2uf2(std::shared_ptr<std::iostream> in, std::shared_ptr<std::iostream> out, uint32_t address, uint32_t family_id, uint32_t abs_block_loc=0, bool verbose=false);
+int elf2uf2(std::shared_ptr<std::iostream> in, std::shared_ptr<std::iostream> out, uint32_t family_id, uint32_t package_addr=0, uint32_t abs_block_loc=0, bool verbose=false);
 
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -6180,10 +6180,10 @@ bool uf2_convert_command::execute(device_map &devices) {
     #endif
     if (get_file_type() == filetype::elf) {
         uint32_t package_address = settings.offset_set ? settings.offset : 0;
-        elf2uf2(in, out, family_id, package_address, settings.uf2.abs_block_loc);
+        elf2uf2(in, out, family_id, package_address, settings.uf2.abs_block_loc, settings.verbose);
     } else if (get_file_type() == filetype::bin) {
         uint32_t address = settings.offset_set ? settings.offset : FLASH_START;
-        bin2uf2(in, out, address, family_id, settings.uf2.abs_block_loc);
+        bin2uf2(in, out, address, family_id, settings.uf2.abs_block_loc, settings.verbose);
     } else {
         fail(ERROR_ARGS, "Convert currently only from ELF/BIN to UF2\n");
     }


### PR DESCRIPTION
Pass the settings.verbose setting to elf2uf2.cpp functions, to add verbose output to `picotool uf2 convert`

Fixes #185