### PR TITLE
Don't rely on unsequenced evaluation order in bintool/metadata.h (#187)

### DIFF
--- a/bintool/metadata.h
+++ b/bintool/metadata.h
@@ -255,7 +255,9 @@ struct partition_table_item : public single_byte_size_item {
             new_p.flags = permissions_flags & (~PICOBIN_PARTITION_PERMISSIONS_BITS);
 
             if (new_p.flags & PICOBIN_PARTITION_FLAGS_HAS_ID_BITS) {
-                new_p.id = (uint64_t)data[i++] | ((uint64_t)data[i++] << 32);
+                uint32_t low = data[i++];
+                uint32_t high = data[i++];
+                new_p.id = (uint64_t)low | ((uint64_t)high << 32);
             }
 
             uint8_t num_extra_families = (new_p.flags & PICOBIN_PARTITION_FLAGS_ACCEPTS_NUM_EXTRA_FAMILIES_BITS) >> PICOBIN_PARTITION_FLAGS_ACCEPTS_NUM_EXTRA_FAMILIES_LSB;


### PR DESCRIPTION
With the following compiler:
% /Library/Developer/CommandLineTools/usr/bin/c++ --version Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin

I was getting the following warning:

metadata.h:258:44: warning: multiple unsequenced modifications to 'i' [-Wunsequenced]

It appears as though the code relies on the leftmost i++ happening first, followed by the rightmost, but the language seemingly provides no such guarantee.

Fix this by reading the low and high words in order, then combining them, rather than doing so in a single expression.