### PR TITLE
Update CMake Pico SDK dependence to 2.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ if (NOT EXISTS ${PICO_SDK_PATH})
 endif ()
 include(${PICO_SDK_PATH}/pico_sdk_version.cmake)
 
-if (PICO_SDK_VERSION_STRING VERSION_LESS "2.0.0")
-    message(FATAL_ERROR "Raspberry Pi Pico SDK version 2.0.0 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
+if (PICO_SDK_VERSION_STRING VERSION_LESS "2.1.0")
+    message(FATAL_ERROR "Raspberry Pi Pico SDK version 2.1.0 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
 endif()
 
 # Set PICOTOOL_CODE_OTP to compile OTP definitions in - otherwise, they are included from JSON


### PR DESCRIPTION
This was missed for the 2.1.0 release in df21059f7ca6f1babc7f1f3b92122cacffc85951 - already causing some confusion with users building picotool 2.1.0 against SDK 2.0.0 (eg https://forums.raspberrypi.com/viewtopic.php?t=380666#p2275730).

Do we want to push this straight to master, given it affects people cloning the master branch? The dependency on 2.1.0 is required due to moved headers (eg boot_bootrom_headers) and added UF2 constants.