### PR TITLE
Picotool dependencies solved with Nix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,10 +80,11 @@ if (NOT PICOTOOL_NO_LIBUSB)
     add_dependencies(xip_ram_perms_elf xip_ram_perms)
     set_property(TARGET xip_ram_perms_elf PROPERTY IMPORTED_LOCATION ${XIP_RAM_PERMS_ELF})
     # copy xip_ram_perms.elf into build directory
-    add_custom_command(TARGET xip_ram_perms
-        COMMAND ${CMAKE_COMMAND} -E copy ${XIP_RAM_PERMS_ELF} ${CMAKE_BINARY_DIR}/xip_ram_perms.elf
-        DEPENDS xip_ram_perms
+    add_custom_command(TARGET xip_ram_perms POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${XIP_RAM_PERMS_ELF} ${CMAKE_BINARY_DIR}/xip_ram_perms.elf
     )
+
+    add_dependencies(xip_ram_perms xip_ram_perms)
 
     # compile flash_id
     ExternalProject_Add(flash_id
@@ -104,10 +105,11 @@ if (NOT PICOTOOL_NO_LIBUSB)
     add_dependencies(flash_id_bin flash_id)
     set_property(TARGET flash_id_bin PROPERTY IMPORTED_LOCATION ${FLASH_ID_BIN})
     # copy flash_id.bin into build directory
-    add_custom_command(TARGET flash_id
-        COMMAND ${CMAKE_COMMAND} -E copy ${FLASH_ID_BIN} ${CMAKE_BINARY_DIR}/flash_id.bin
-        DEPENDS flash_id
+    add_custom_command(TARGET flash_id POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${FLASH_ID_BIN} ${CMAKE_BINARY_DIR}/flash_id.bin
     )
+
+    add_dependencies(flash_id flash_id)
 
     # We want to generate headers from WELCOME.HTM etc.
     ExternalProject_Add(otp_header_parser

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ sudo apt install build-essential pkg-config libusb-1.0-0-dev cmake
 
 > If libusb-1.0-0-dev is not installed, picotool still builds, but it omits all options that deal with managing a pico via USB (load, save, erase, verify, reboot). Builds that do not include USB support can be recognized because these commands also do not appear in the help command. The build output message 'libUSB is not found - no USB support will be built' also appears in the build logs.
 
+##### Alternative to install dependencies with nix
+
+Instead of having to manually install every dependency, it can be managed through [Nix](https://nixos.org/download/) / [Lix](https://lix.systems/install/).
+
+Before building the project, just use the following command: `nix develop`
+
+
 Then simply build like a normal CMake project:
 
 ```console

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1739302066,
+        "narHash": "sha256-G0n8Kg4fp5ySKtmnpD+97NwQYJWeC2iHvIukq4IIvyw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e3ade6a61ec8b56318877de06846d59d86eb2565",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"] (system:
       let
         pkgs = import nixpkgs { inherit system; };
 
@@ -18,13 +18,25 @@
           sha256 = "0qzj3x7vqrflirgbxmji2m5fqxha7ib95nsg6glhpn7id7lkb9s0";
         };
 
+        commonDeps = [ 
+          pkgs.cmake
+          pkgs.libusb1
+        ];
+
+        macDeps = [
+          pkgs.llvmPackages.clang
+          pkgs.libiconv
+        ];
+
+        linuxDeps = [
+          pkgs.gcc
+        ];
+
+        buildDeps = if pkgs.stdenv.isDarwin then commonDeps ++ macDeps else commonDeps ++ linuxDeps;
+
       in {
         devShells.default = pkgs.mkShell {
-          buildInputs = [
-            pkgs.cmake
-            pkgs.gcc
-            pkgs.libusb1
-          ];
+          buildInputs = buildDeps;
         shellHook = ''
               export PICO_SDK_PATH=${picoSdk}
               echo "PICO_SDK_PATH set to ${picoSdk}"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+# {
+#   description = "A flake for compiling picotool from Raspberry Pi";
+
+#   inputs = {
+#     nixpkgs.url = "github:nixos/nixpkgs";
+#     flake-utils.url = "github:numtide/flake-utils";
+#   };
+
+#   outputs = { self, flake-utils, nixpkgs }:
+#   flake-utils.lib.eachSystem [ flake-utils.lib.system.x86_64-linux]
+#   (system:
+#     let
+#       pkgs = nixpkgs.legacyPackages.${system};
+      
+#       dependencies =  with pkgs; [
+#         libusb1
+#         cmake
+#         pkg-config
+#         libgcc
+#       ];
+        
+  
+#   in {
+
+#   }
+#   );
+
+
+# }
+{
+  description = "A flake for compiling picotool from Raspberry Pi";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        picoSdk = pkgs.fetchFromGitHub {
+          owner = "raspberrypi";
+          repo = "pico-sdk";
+          rev = "master"; 
+          sha256 = "0qzj3x7vqrflirgbxmji2m5fqxha7ib95nsg6glhpn7id7lkb9s0";
+        };
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.cmake
+            pkgs.gcc
+            pkgs.libusb1
+          ];
+        shellHook = ''
+              export PICO_SDK_PATH=${picoSdk}
+              echo "PICO_SDK_PATH set to ${picoSdk}"
+            '';
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
       let
         pkgs = import nixpkgs { inherit system; };
 
@@ -17,6 +17,7 @@
           rev = "master"; 
           sha256 = "0qzj3x7vqrflirgbxmji2m5fqxha7ib95nsg6glhpn7id7lkb9s0";
         };
+
       in {
         devShells.default = pkgs.mkShell {
           buildInputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -1,32 +1,3 @@
-# {
-#   description = "A flake for compiling picotool from Raspberry Pi";
-
-#   inputs = {
-#     nixpkgs.url = "github:nixos/nixpkgs";
-#     flake-utils.url = "github:numtide/flake-utils";
-#   };
-
-#   outputs = { self, flake-utils, nixpkgs }:
-#   flake-utils.lib.eachSystem [ flake-utils.lib.system.x86_64-linux]
-#   (system:
-#     let
-#       pkgs = nixpkgs.legacyPackages.${system};
-      
-#       dependencies =  with pkgs; [
-#         libusb1
-#         cmake
-#         pkg-config
-#         libgcc
-#       ];
-        
-  
-#   in {
-
-#   }
-#   );
-
-
-# }
 {
   description = "A flake for compiling picotool from Raspberry Pi";
 


### PR DESCRIPTION
CMakeLists.txt update to eliminate warning on newer versions of `cmake`

Added flake to avoid installation of individual dependencies for Linux and MacOS

README file updated to explain how to use `nix`