### PR TITLE
Fix possible segfault in UF2 save

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4336,7 +4336,7 @@ bool save_command::execute(device_map &devices) {
                 block.block_no = offset / PAGE_SIZE;
                 assert(size <= PAGE_SIZE);
                 memcpy(block.data, buffer, size);
-                if (size < PAGE_SIZE) memset(block.data + size, 0, PAGE_SIZE);
+                if (size < PAGE_SIZE) memset(block.data + size, 0, PAGE_SIZE - size);
                 if (1 != fwrite(&block, sizeof(block), 1, out)) {
                     fail_write_error();
                 }


### PR DESCRIPTION
When saving a binary to a UF2 which is not a multiple of `PAGE_SIZE`, this `memset` can cause a segfault on the final block, as it writes past the end of `block.data`. This fixes that issue.