### PR TITLE
Speedup some picotool commands

### DIFF
--- a/bintool/bintool.cpp
+++ b/bintool/bintool.cpp
@@ -375,6 +375,9 @@ std::vector<std::unique_ptr<block>> get_all_blocks(std::vector<uint8_t> &bin, ui
         }
         auto offset = next_block_addr - current_bin_start;
         std::vector<uint32_t> words = lsb_bytes_to_words(bin.begin() + offset, bin.end());
+        if (words.front() != PICOBIN_BLOCK_MARKER_START) {
+            fail(ERROR_UNKNOWN, "Block loop is not valid - no block found at %08x\n", (int)(next_block_addr));
+        }
         words.erase(words.begin());
         DEBUG_LOG("Checking block at %x\n", next_block_addr);
         DEBUG_LOG("Starts with %x %x %x %x\n", words[0], words[1], words[2], words[3]);

--- a/bintool/bintool.cpp
+++ b/bintool/bintool.cpp
@@ -319,11 +319,14 @@ std::unique_ptr<block> get_last_block(std::vector<uint8_t> &bin, uint32_t storag
     uint32_t next_block_addr = first_block->physical_addr + first_block->next_block_rel;
     std::unique_ptr<block> new_first_block;
     uint32_t read_size = PICOBIN_MAX_BLOCK_SIZE;
+    uint32_t current_bin_start = storage_addr;
     while (true) {
-        auto offset = next_block_addr - storage_addr;
-        if (offset + read_size > bin.size() && more_cb != nullptr) {
-            more_cb(bin, offset + read_size);
+        if (next_block_addr + read_size > current_bin_start + bin.size() && more_cb != nullptr) {
+            DEBUG_LOG("Reading into bin %08x+%x\n", next_block_addr, read_size);
+            more_cb(bin, next_block_addr, read_size);
+            current_bin_start = next_block_addr;
         }
+        auto offset = next_block_addr - current_bin_start;
         std::vector<uint32_t> words = lsb_bytes_to_words(bin.begin() + offset, bin.end());
         if (words.front() != PICOBIN_BLOCK_MARKER_START) {
             fail(ERROR_UNKNOWN, "Block loop is not valid - no block found at %08x\n", (int)(next_block_addr));
@@ -362,12 +365,15 @@ std::vector<std::unique_ptr<block>> get_all_blocks(std::vector<uint8_t> &bin, ui
     uint32_t next_block_addr = first_block->physical_addr + first_block->next_block_rel;
     std::vector<std::unique_ptr<block>> all_blocks;
     uint32_t read_size = PICOBIN_MAX_BLOCK_SIZE;
+    uint32_t current_bin_start = storage_addr;
     while (true) {
         std::unique_ptr<block> new_first_block;
-        auto offset = next_block_addr - storage_addr;
-        if (offset + read_size > bin.size() && more_cb != nullptr) {
-            more_cb(bin, offset + read_size);
+        if (next_block_addr + read_size > current_bin_start + bin.size() && more_cb != nullptr) {
+            DEBUG_LOG("Reading into bin %08x+%x\n", next_block_addr, read_size);
+            more_cb(bin, next_block_addr, read_size);
+            current_bin_start = next_block_addr;
         }
+        auto offset = next_block_addr - current_bin_start;
         std::vector<uint32_t> words = lsb_bytes_to_words(bin.begin() + offset, bin.end());
         words.erase(words.begin());
         DEBUG_LOG("Checking block at %x\n", next_block_addr);
@@ -698,7 +704,7 @@ std::vector<uint8_t> get_lm_hash_data(elf_file *elf, block *new_block, bool clea
 }
 
 
-std::vector<uint8_t> get_lm_hash_data(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *new_block, bool clear_sram = false) {
+std::vector<uint8_t> get_lm_hash_data(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *new_block, get_more_bin_cb more_cb, bool clear_sram = false) {
     std::vector<uint8_t> to_hash;
     std::shared_ptr<load_map_item> load_map = new_block->get_item<load_map_item>();
     if (load_map == nullptr) {
@@ -729,6 +735,7 @@ std::vector<uint8_t> get_lm_hash_data(std::vector<uint8_t> bin, uint32_t storage
     } else {
         DEBUG_LOG("Already has load map, so hashing that\n");
         // todo hash existing load map
+        uint32_t current_bin_start = storage_addr;
         for(const auto &entry : load_map->entries) {
             if (entry.storage_address == 0) {
                 std::copy(
@@ -737,7 +744,15 @@ std::vector<uint8_t> get_lm_hash_data(std::vector<uint8_t> bin, uint32_t storage
                     std::back_inserter(to_hash));
                 DEBUG_LOG("CLEAR %08x + %08x\n", (int)entry.runtime_address, (int)entry.size);
             } else {
-                uint32_t rel_addr = entry.storage_address - storage_addr;
+                if (entry.storage_address + entry.size > current_bin_start + bin.size()) {
+                    if (more_cb == nullptr) {
+                        fail(ERROR_NOT_POSSIBLE, "BIN does not contain data for load_map entry %08x->%08x", entry.storage_address, entry.storage_address + entry.size);
+                    }
+                    DEBUG_LOG("Reading into bin %08x+%x\n", entry.storage_address, entry.size);
+                    more_cb(bin, entry.storage_address, entry.size);
+                    current_bin_start = entry.storage_address;
+                }
+                uint32_t rel_addr = entry.storage_address - current_bin_start;
                 std::copy(
                     bin.begin() + rel_addr,
                     bin.begin() + rel_addr + entry.size,
@@ -787,10 +802,10 @@ int hash_andor_sign(elf_file *elf, block *new_block, const public_t public_key, 
 
 
 std::vector<uint8_t> hash_andor_sign(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *new_block, const public_t public_key, const private_t private_key, bool hash_value, bool sign, bool clear_sram) {
-    std::vector<uint8_t> to_hash = get_lm_hash_data(bin, storage_addr, runtime_addr, new_block, clear_sram);
+    std::vector<uint8_t> to_hash = get_lm_hash_data(bin, storage_addr, runtime_addr, new_block, nullptr, clear_sram);
 
-    hash_andor_sign_block(new_block, public_key, private_key, hash_value, sign, bin);
-    
+    hash_andor_sign_block(new_block, public_key, private_key, hash_value, sign, to_hash);
+
     auto tmp = new_block->to_words();
     std::vector<uint8_t> data = words_to_lsb_bytes(tmp.begin(), tmp.end());
 
@@ -800,7 +815,7 @@ std::vector<uint8_t> hash_andor_sign(std::vector<uint8_t> bin, uint32_t storage_
 }
 
 
-void verify_block(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *block, verified_t &hash_verified, verified_t &sig_verified) {
+void verify_block(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *block, verified_t &hash_verified, verified_t &sig_verified, get_more_bin_cb more_cb) {
     std::shared_ptr<load_map_item> load_map = block->get_item<load_map_item>();
     std::shared_ptr<hash_def_item> hash_def = block->get_item<hash_def_item>();
     hash_verified = none;
@@ -808,7 +823,7 @@ void verify_block(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runt
     if (load_map == nullptr || hash_def == nullptr) {
         return;
     }
-    std::vector<uint8_t> to_hash = get_lm_hash_data(bin, storage_addr, runtime_addr, block, false);
+    std::vector<uint8_t> to_hash = get_lm_hash_data(bin, storage_addr, runtime_addr, block, more_cb, false);
 
     // auto it = std::find(block->items.begin(), block->items.end(), hash_def);
     // assert (it != block->items.end());

--- a/bintool/bintool.h
+++ b/bintool/bintool.h
@@ -29,7 +29,7 @@ block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block);
 #endif
 
 // Bins
-typedef std::function<void(std::vector<uint8_t> &bin, uint32_t size)> get_more_bin_cb;
+typedef std::function<void(std::vector<uint8_t> &bin, uint32_t offset, uint32_t size)> get_more_bin_cb;
 std::unique_ptr<block> find_first_block(std::vector<uint8_t> bin, uint32_t storage_addr);
 std::unique_ptr<block> get_last_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, get_more_bin_cb more_cb = nullptr);
 std::vector<std::unique_ptr<block>> get_all_blocks(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, get_more_bin_cb more_cb = nullptr);
@@ -38,5 +38,5 @@ uint32_t calc_checksum(std::vector<uint8_t> bin);
 #if HAS_MBEDTLS
     std::vector<uint8_t> hash_andor_sign(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *new_block, const public_t public_key, const private_t private_key, bool hash_value, bool sign, bool clear_sram = false);
     std::vector<uint8_t> encrypt(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *new_block, const private_t aes_key, const public_t public_key, const private_t private_key, bool hash_value, bool sign);
-    void verify_block(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *block, verified_t &hash_verified, verified_t &sig_verified);
+    void verify_block(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *block, verified_t &hash_verified, verified_t &sig_verified, get_more_bin_cb more_cb = nullptr);
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -1868,7 +1868,7 @@ struct picoboot_memory_access : public memory_access {
     }
 
     void read(uint32_t address, uint8_t *buffer, unsigned int size, __unused bool zero_fill) override {
-        if (flash == get_memory_type(address, model) && settings.use_flash_cache) {
+        if (settings.use_flash_cache && flash == get_memory_type(address, model)) {
             read_cached(address, buffer, size);
         } else {
             read_raw(address, buffer, size);

--- a/main.cpp
+++ b/main.cpp
@@ -412,6 +412,7 @@ struct _settings {
     uint32_t family_id = 0;
     bool quiet = false;
     bool verbose = false;
+    bool use_flash_cache = false;
 
     struct {
         int redundancy = -1;
@@ -1867,7 +1868,7 @@ struct picoboot_memory_access : public memory_access {
     }
 
     void read(uint32_t address, uint8_t *buffer, unsigned int size, __unused bool zero_fill) override {
-        if (flash == get_memory_type(address, model)) {
+        if (flash == get_memory_type(address, model) && settings.use_flash_cache) {
             read_cached(address, buffer, size);
         } else {
             read_raw(address, buffer, size);
@@ -3024,6 +3025,8 @@ void info_guts(memory_access &raw_access, picoboot::connection *con) {
 #else
 void info_guts(memory_access &raw_access, void *con) {
 #endif
+    // Use flash caching
+    settings.use_flash_cache = true;
     try {
         struct group {
             explicit group(string name, bool enabled = true, int min_tab = 0) : name(std::move(name)), enabled(enabled), min_tab(min_tab) {}

--- a/main.cpp
+++ b/main.cpp
@@ -4389,12 +4389,11 @@ bool save_command::execute(device_map &devices) {
             bool ok = true;
             {
                 progress_bar bar("Verifying " + memory_names[type] + ": ");
-                uint32_t batch_size = FLASH_SECTOR_ERASE_SIZE;
                 vector<uint8_t> file_buf;
                 vector<uint8_t> device_buf;
                 uint32_t pos = mem_range.from;
-                for (uint32_t base = mem_range.from; base < mem_range.to && ok; base += batch_size) {
-                    uint32_t this_batch = std::min(std::min(mem_range.to, end) - base, batch_size);
+                for (uint32_t base = mem_range.from; base < mem_range.to && ok; base += chunk_size) {
+                    uint32_t this_batch = std::min(std::min(mem_range.to, end) - base, chunk_size);
                     // note we pass zero_fill = true in case the file has holes, but this does
                     // mean that the verification will fail if those holes are not filled with zeros
                     // on the device
@@ -4650,7 +4649,7 @@ bool load_guts(picoboot::connection con, iostream_memory_access &file_access) {
             bool ok = true;
             {
                 progress_bar bar("Verifying " + memory_names[type] + ": ");
-                uint32_t batch_size = FLASH_SECTOR_ERASE_SIZE;
+                uint32_t batch_size = std::max(mem_range.len() / 100, FLASH_SECTOR_ERASE_SIZE);
                 vector<uint8_t> file_buf;
                 vector<uint8_t> device_buf;
                 uint32_t pos = mem_range.from;
@@ -5285,7 +5284,7 @@ bool verify_command::execute(device_map &devices) {
                     progress_bar bar("Verifying " + memory_names[t1] + ": ");
                     vector<uint8_t> file_buf;
                     vector<uint8_t> device_buf;
-                    uint32_t batch_size = 1024;
+                    uint32_t batch_size = std::max(mem_range.len() / 100, FLASH_SECTOR_ERASE_SIZE);
                     for(uint32_t base = mem_range.from; base < mem_range.to && ok; base += batch_size) {
                         uint32_t this_batch = std::min(mem_range.to - base, batch_size);
                         // note we pass zero_fill = true in case the file has holes, but this does

--- a/main.cpp
+++ b/main.cpp
@@ -291,6 +291,14 @@ private:
     map<uint32_t, pair<uint32_t, T>> m;
 };
 
+
+// Calculate chunk size for load/save/verify
+// Returns size/100 rounded up to FLASH_SECTOR_ERASE_SIZE
+uint32_t calculate_chunk_size(uint32_t size) {
+    return ((size/100 + FLASH_SECTOR_ERASE_SIZE - 1) & ~(FLASH_SECTOR_ERASE_SIZE - 1));
+}
+
+
 using cli::group;
 using cli::option;
 using cli::integer;
@@ -4308,7 +4316,7 @@ bool save_command::execute(device_map &devices) {
         fail(ERROR_NOT_POSSIBLE, "Save range crosses unmapped memory");
     }
     uint32_t size = end - start;
-    uint32_t chunk_size = std::max(size / 100, FLASH_SECTOR_ERASE_SIZE);
+    uint32_t chunk_size = calculate_chunk_size(size);
 
     std::function<void(FILE *out, const uint8_t *buffer, unsigned int size, unsigned int offset)> writer256 = [](FILE *out, const uint8_t *buffer, unsigned int size, unsigned int offset) { assert(false); };
     uf2_block block;
@@ -4603,8 +4611,7 @@ bool load_guts(picoboot::connection con, iostream_memory_access &file_access) {
         {
             progress_bar bar("Loading into " + memory_names[type] + ": ");
             // Use batches of size/100 rounded up to FLASH_SECTOR_ERASE_SIZE
-            uint32_t batch_size = std::max(FLASH_SECTOR_ERASE_SIZE,
-                (mem_range.len()/100 + FLASH_SECTOR_ERASE_SIZE - 1) & ~(FLASH_SECTOR_ERASE_SIZE - 1));
+            uint32_t batch_size = calculate_chunk_size(mem_range.len());
             bool ok = true;
             vector<uint8_t> file_buf;
             vector<uint8_t> device_buf;
@@ -4649,7 +4656,7 @@ bool load_guts(picoboot::connection con, iostream_memory_access &file_access) {
             bool ok = true;
             {
                 progress_bar bar("Verifying " + memory_names[type] + ": ");
-                uint32_t batch_size = std::max(mem_range.len() / 100, FLASH_SECTOR_ERASE_SIZE);
+                uint32_t batch_size = calculate_chunk_size(mem_range.len());
                 vector<uint8_t> file_buf;
                 vector<uint8_t> device_buf;
                 uint32_t pos = mem_range.from;
@@ -5284,7 +5291,7 @@ bool verify_command::execute(device_map &devices) {
                     progress_bar bar("Verifying " + memory_names[t1] + ": ");
                     vector<uint8_t> file_buf;
                     vector<uint8_t> device_buf;
-                    uint32_t batch_size = std::max(mem_range.len() / 100, FLASH_SECTOR_ERASE_SIZE);
+                    uint32_t batch_size = calculate_chunk_size(mem_range.len());
                     for(uint32_t base = mem_range.from; base < mem_range.to && ok; base += batch_size) {
                         uint32_t this_batch = std::min(mem_range.to - base, batch_size);
                         // note we pass zero_fill = true in case the file has holes, but this does

--- a/picoboot_connection/picoboot_connection_cxx.cpp
+++ b/picoboot_connection/picoboot_connection_cxx.cpp
@@ -118,7 +118,12 @@ void connection::write(uint32_t addr, uint8_t *buffer, uint32_t len) {
 }
 
 void connection::read(uint32_t addr, uint8_t *buffer, uint32_t len) {
-    wrap_call([&] { return picoboot_read(device, addr, buffer, len); });
+    // Workaround due to picoboot interface not supporting reads over 4MiB
+    uint32_t max_chunk_size = 0x00400000;
+    for (uint32_t i=0; i < len; i += max_chunk_size) {
+        uint32_t read_size = std::min(len - i, max_chunk_size);
+        wrap_call([&] { return picoboot_read(device, addr + i, buffer + i, read_size); });
+    }
 }
 
 void connection::otp_write(struct picoboot_otp_cmd *otp_cmd, uint8_t *buffer, uint32_t len) {

--- a/picoboot_connection/picoboot_connection_cxx.cpp
+++ b/picoboot_connection/picoboot_connection_cxx.cpp
@@ -23,6 +23,7 @@ std::map<enum picoboot_status, const char *> status_code_strings = {
         {picoboot_status::PICOBOOT_INVALID_TRANSFER_LENGTH, "invalid transfer length"},
         {picoboot_status::PICOBOOT_REBOOTING, "rebooting"},
         {picoboot_status::PICOBOOT_UNKNOWN_CMD, "unknown cmd"},
+        {picoboot_status::PICOBOOT_UNKNOWN_ERROR, "unknown error"},
         {picoboot_status::PICOBOOT_INVALID_STATE, "invalid state"},
         {picoboot_status::PICOBOOT_INVALID_ADDRESS, "invalid argument"},
         {picoboot_status::PICOBOOT_NOT_PERMITTED, "permission failure"},


### PR DESCRIPTION
This offers substantial performance improvements for `info` (with no signing/hashing) and `save`/`verify`, and small improvements for `load`. The performance figures for a 4MiB binary on Pico 2 are below, and on Pico the figures are also improved (although with less of an improvement for `info` due to the Pico not including metadata blocks). This fixes #204.

| Command | speedups | 2.1.1 | 2.1.0 | 2.0.0 |
|--------|--------|--------|--------|--------|
| `info` | 0.056 | 9.156 | 18.488 | 9.346 |
| `info` (hashed binary) | 9.156 | 9.173 | 36.747 | 18.408 |
| `save` | 9.8 | 21.747 | 31.28 | 35.869 |
| `save --range` | 9.744 | 40.058 | 23.325 | 26.087 |
| `load` | 65.121 | 70.688 | 72.645 | 89.636 |

The main fixes have been:
- Batching reads/writes into >4096 byte chunks, rather than the existing smaller chunk sizes (eg 256 byte chunks for `save`)
- Doing a sparse read of the block loop when not verifying the binary hash and only read the whole binary when verifying the hash, rather than always reading the whole binary in case the hash needs to be verified.

Also includes 3 drive-by fixes:
- Fixed a bug with truncated binaries, where the metadata search would get into an infinite loop - this fix was already in `get_last_block` but was missing from `get_all_blocks`
- Replace `<unknown>` printout for `PICOBOOT_UNKNOWN_ERROR` with `unknown error`, to clarify the error was not an unknown error value, just an unknown error - the `<unknown>` printout is still used for other unknown error values
- Workaround picoboot interface not supporting >4MiB reads - this only crops up when validating the hash/signature for >4MiB binaries, as it reads the whole binary in one go