### PR TITLE
Reference RP2350-E15 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1031,7 +1031,7 @@ Device Descriptor:
 
 ### permissions
 
-This command will run a binary on your device in order to set the OTP permissions, as these are not directly accessible from `picotool` on due to errata RP2350-E15 on RP2350 A2. 
+This command will run a binary on your device in order to set the OTP permissions, as these are not directly accessible from `picotool` due to errata RP2350-E15 on RP2350 A2. 
 Because it runs a binary, the binary needs to be signed if secure boot is enabled. The binary will light an LED when running, which
 can be configured using the `--led` argument. You can define your OTP permissions in a json file, an example of which
 is in [sample-permissions.json](json/sample-permissions.json). The schema for this JSON file is [here](json/schemas/permissions-schema.json)

--- a/README.md
+++ b/README.md
@@ -1032,8 +1032,8 @@ Device Descriptor:
 ### permissions
 
 This command will run a binary on your device in order to set the OTP permissions, as these are not directly accessible from `picotool` on due to errata RP2350-E15 on RP2350 A2. 
-Because it runs a binary, the binary needs to be signed if secure boot is enabled. The binary will print what it is doing over UART, which
-can be configured using the UART Configuration arguments. You can define your OTP permissions in a json file, an example of which
+Because it runs a binary, the binary needs to be signed if secure boot is enabled. The binary will light an LED when running, which
+can be configured using the `--led` argument. You can define your OTP permissions in a json file, an example of which
 is in [sample-permissions.json](json/sample-permissions.json). The schema for this JSON file is [here](json/schemas/permissions-schema.json)
 
 ```text

--- a/README.md
+++ b/README.md
@@ -1031,8 +1031,8 @@ Device Descriptor:
 
 ### permissions
 
-This command will run a binary on your device in order to set the OTP permissions, as these are not directly accessible from `picotool` on due to the default permissions settings required to fix  errata XXX on RP2350. 
-Because it runs a binary, the binary needs to be sign it if secure boot is enabled. The binary will print what it is doing over uart, which
+This command will run a binary on your device in order to set the OTP permissions, as these are not directly accessible from `picotool` on due to errata RP2350-E15 on RP2350 A2. 
+Because it runs a binary, the binary needs to be signed if secure boot is enabled. The binary will print what it is doing over UART, which
 can be configured using the UART Configuration arguments. You can define your OTP permissions in a json file, an example of which
 is in [sample-permissions.json](json/sample-permissions.json). The schema for this JSON file is [here](json/schemas/permissions-schema.json)
 


### PR DESCRIPTION
Note the specific errata relevant  for the otp permissions command in the README.

---

I assume the 'XXX' errata here is RP2350-E15 ("The bootrom otp_access() function applies incorrect access permission to pages 62 & 63"). I didn't understand the existing comment so I updated it to what I think is meant based on reading the docs but it bears checking. 