### PR TITLE
Fixup to work with mbedtls 3.x

### DIFF
--- a/bintool/bintool.cpp
+++ b/bintool/bintool.cpp
@@ -50,7 +50,15 @@ int read_keys(const std::string &filename, public_t *public_key, private_t *priv
     int rc;
 
     mbedtls_pk_init(&pk_ctx);
+#if MBEDTLS_VERSION_MAJOR == 2
     rc = mbedtls_pk_parse_keyfile(&pk_ctx, filename.c_str(), NULL);
+#else
+    // This rng is only used for blinding when reading the key file
+    // As this should only be done on a secure computer, blinding is not required, so it's fine to not actually seed it with any entropy
+    mbedtls_ctr_drbg_context ctr_drbg;
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+    rc = mbedtls_pk_parse_keyfile(&pk_ctx, filename.c_str(), NULL, mbedtls_ctr_drbg_random, &ctr_drbg);
+#endif
     if (rc != 0) {
         char error_string[128];
         mbedtls_strerror(rc, error_string, sizeof(error_string));

--- a/bintool/bintool.cpp
+++ b/bintool/bintool.cpp
@@ -50,14 +50,14 @@ int read_keys(const std::string &filename, public_t *public_key, private_t *priv
     int rc;
 
     mbedtls_pk_init(&pk_ctx);
-#if MBEDTLS_VERSION_MAJOR == 2
-    rc = mbedtls_pk_parse_keyfile(&pk_ctx, filename.c_str(), NULL);
-#else
+#if MBEDTLS_VERSION_MAJOR >= 3
     // This rng is only used for blinding when reading the key file
     // As this should only be done on a secure computer, blinding is not required, so it's fine to not actually seed it with any entropy
     mbedtls_ctr_drbg_context ctr_drbg;
     mbedtls_ctr_drbg_init(&ctr_drbg);
     rc = mbedtls_pk_parse_keyfile(&pk_ctx, filename.c_str(), NULL, mbedtls_ctr_drbg_random, &ctr_drbg);
+#else
+    rc = mbedtls_pk_parse_keyfile(&pk_ctx, filename.c_str(), NULL);
 #endif
     if (rc != 0) {
         char error_string[128];

--- a/bintool/mbedtls_wrapper.c
+++ b/bintool/mbedtls_wrapper.c
@@ -175,7 +175,11 @@ void mb_sign_sha256(const uint8_t *entropy, size_t entropy_size, const message_d
 
     DEBUG_LOG(" ok (key size: %d bits)\n", (int) ctx_sign.grp.pbits);
 
+#if MBEDTLS_VERSION_MAJOR == 2
     ret = mbedtls_ecp_check_pub_priv(&ctx_sign, &ctx_sign);
+#else
+    ret = mbedtls_ecp_check_pub_priv(&ctx_sign, &ctx_sign, mbedtls_ctr_drbg_random, &ctr_drbg);
+#endif
     DEBUG_LOG("Pub Priv Returned %d\n", ret);
 
     dump_pubkey("  + Public key: ", &ctx_sign);
@@ -187,7 +191,11 @@ void mb_sign_sha256(const uint8_t *entropy, size_t entropy_size, const message_d
 
     if ((ret = mbedtls_ecdsa_write_signature(&ctx_sign, MBEDTLS_MD_SHA256,
                                              m->bytes, sizeof(m->bytes),
-                                             out->der, &out->der_len,
+                                             out->der,
+                                             #if MBEDTLS_VERSION_MAJOR >= 3
+                                             sizeof(out->der),
+                                             #endif
+                                             &out->der_len,
                                              mbedtls_ctr_drbg_random, &ctr_drbg)) != 0) {
         DEBUG_LOG(" failed\n  ! mbedtls_ecdsa_write_signature returned %d\n", ret);
         return;

--- a/bintool/mbedtls_wrapper.c
+++ b/bintool/mbedtls_wrapper.c
@@ -175,10 +175,10 @@ void mb_sign_sha256(const uint8_t *entropy, size_t entropy_size, const message_d
 
     DEBUG_LOG(" ok (key size: %d bits)\n", (int) ctx_sign.grp.pbits);
 
-#if MBEDTLS_VERSION_MAJOR == 2
-    ret = mbedtls_ecp_check_pub_priv(&ctx_sign, &ctx_sign);
-#else
+#if MBEDTLS_VERSION_MAJOR >= 3
     ret = mbedtls_ecp_check_pub_priv(&ctx_sign, &ctx_sign, mbedtls_ctr_drbg_random, &ctr_drbg);
+#else
+    ret = mbedtls_ecp_check_pub_priv(&ctx_sign, &ctx_sign);
 #endif
     DEBUG_LOG("Pub Priv Returned %d\n", ret);
 

--- a/bintool/mbedtls_wrapper.h
+++ b/bintool/mbedtls_wrapper.h
@@ -4,6 +4,7 @@ extern "C" {
 #endif
 
 #undef MBEDTLS_ECDSA_DETERMINISTIC
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -16,6 +17,7 @@ extern "C" {
 #include <mbedtls/pk.h>
 #include <mbedtls/ecp.h>
 #include <mbedtls/aes.h>
+#include <mbedtls/version.h>
 
 #ifdef __cplusplus
 #define _Static_assert static_assert


### PR DESCRIPTION
CMake 4.0 has been released, which requires Mbedtls 3.x. This is because Mbedtls 2.x sets a min CMake version of 2.8.12, but CMake 4.0 throws an error if the min version is < 3.5. This is already causing some picotool CI failures, as some runners seem to have the latest CMake (https://github.com/raspberrypi/picotool/actions/runs/14196997735/job/39774407801#step:8:32). This needs updating in the SDK too, see https://github.com/raspberrypi/pico-sdk/issues/2391

The fix is to allow access to the private variables required, and some changed function signatures. This maintains compatibility with mbedtls 2.x using #ifs on the MBEDTLS_VERSION_MAJOR.