### PR TITLE
Add TBYB info to output

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3120,6 +3120,10 @@ void info_guts(memory_access &raw_access, void *con) {
                 } else if (image_def->image_type() == type_data) {
                     info_pair("image type", "data");
                 }
+                
+                if (image_def->tbyb()) {
+                    info_pair("tbyb", "not bought");
+                }
             }
 
             // Partition Table


### PR DESCRIPTION
Adds TBYB info to the `picotool info` printout, eg:

```
Program Information
 binary start:  0x10000000
 target chip:   RP2350
 image type:    ARM Secure
 tbyb:          not bought
 version:       7.3
 hash:          verified
 signature:     verified
```

I think this is fine to be in the normal `info` printout, rather than the metadata `info -m` printout, as it will only appear if you have a TBYB image