### PR TITLE
Allow DLL libusb libraries with variable

### DIFF
--- a/cmake/FindLIBUSB.cmake
+++ b/cmake/FindLIBUSB.cmake
@@ -59,9 +59,11 @@ else (LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)
     include(FindPackageHandleStandardArgs)
     FIND_PACKAGE_HANDLE_STANDARD_ARGS(LIBUSB DEFAULT_MSG LIBUSB_LIBRARIES LIBUSB_INCLUDE_DIR)
 
-    # Don't use .dll.a libraries, as they require the .dll file to be in the correct location
-    # Replace with .a for static linking instead
-    string(REPLACE ".dll.a" ".a" LIBUSB_LIBRARIES ${LIBUSB_LIBRARIES})
+    if (NOT PICOTOOL_LIBUSB_ALLOW_DLL)
+        # Don't use .dll.a libraries, as they require the .dll file to be in the correct location
+        # Replace with .a for static linking instead
+        string(REPLACE ".dll.a" ".a" LIBUSB_LIBRARIES ${LIBUSB_LIBRARIES})
+    endif()
 
     MARK_AS_ADVANCED(LIBUSB_INCLUDE_DIR LIBUSB_LIBRARIES)
 endif (LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)


### PR DESCRIPTION
Add `PICOTOOL_LIBUSB_ALLOW_DLL` variable to switch back to the old behaviour and use DLL libusb, which was used prior to #126

Fixes #223