### PR TITLE
add missing include

### DIFF
--- a/cli.h
+++ b/cli.h
@@ -19,6 +19,7 @@
 #include <numeric>
 #include <sstream>
 #include <limits>
+#include <cstdint>
 
 /**
  * Note this is a hastily hacked together command line parser.


### PR DESCRIPTION
```
picotool-src/cli.h:425:13: error: ‘uint64_t’ was not declared in this scope [-Wtemplate-body]
  425 |             uint64_t lvalue = std::numeric_limits<uint64_t>::max();
      |             ^~~~~~~~
```
