### PR TITLE
Add instructions to udev rules file, and fix order

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -30,7 +30,7 @@ make
 On Linux you can add udev rules in order to run picotool without sudo:
 
 ```console
-sudo cp udev/99-picotool.rules /etc/udev/rules.d/
+sudo cp udev/60-picotool.rules /etc/udev/rules.d/
 ```
 
 ### Windows

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -17,7 +17,7 @@ sudo apt install build-essential libudev-dev
 On Linux you can add udev rules in order to run picotool without sudo:
 
 ```console
-sudo cp udev/99-picotool.rules /etc/udev/rules.d/
+sudo cp udev/60-picotool.rules /etc/udev/rules.d/
 ```
 
 ### macOS

--- a/udev/60-picotool.rules
+++ b/udev/60-picotool.rules
@@ -1,3 +1,6 @@
+# Copy this file to /etc/udev/rules.d/
+# You can reload the udev rules with "udevadm control --reload"
+
 SUBSYSTEM=="usb", \
     ATTRS{idVendor}=="2e8a", \
     ATTRS{idProduct}=="0003", \


### PR DESCRIPTION
Adding the instructions into the file is useful for linking to the file from elsewhere without needing to explain where to copy it, eg from the Pico VS Code extension

Order fix supercedes #199