### PR TITLE
Minor tidyups

### DIFF
--- a/bintool/bintool.cpp
+++ b/bintool/bintool.cpp
@@ -546,6 +546,11 @@ uint32_t calc_checksum(std::vector<uint8_t> bin) {
 
 #if HAS_MBEDTLS
 void hash_andor_sign_block(block *new_block, const public_t public_key, const private_t private_key, bool hash_value, bool sign, std::vector<uint8_t> to_hash) {
+    if (!(hash_value || sign)) {
+        // Don't need to add anything if not actually hashing or signing
+        return;
+    }
+
     std::shared_ptr<hash_def_item> hash_def = std::make_shared<hash_def_item>(PICOBIN_HASH_SHA256);
     new_block->items.push_back(hash_def);
 

--- a/bintool/metadata.h
+++ b/bintool/metadata.h
@@ -208,6 +208,7 @@ struct partition_table_item : public single_byte_size_item {
             }
             if (name.size() > 0) {
                 char size = name.size();
+                assert(size & 0x7f == size);
                 std::vector<char> name_vec = {size};
                 for (char c : name) {
                     name_vec.push_back(c);

--- a/json/schemas/partition-table-schema.json
+++ b/json/schemas/partition-table-schema.json
@@ -52,7 +52,8 @@
                 "properties": {
                     "name": {
                         "description": "Partition Name",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 127
                     },
                     "id": {
                         "description": "Partition ID",

--- a/main.cpp
+++ b/main.cpp
@@ -6142,7 +6142,13 @@ bool partition_create_command::execute(device_map &devices) {
             }
             new_p.flags |= (link_value << PICOBIN_PARTITION_FLAGS_LINK_VALUE_LSB) & PICOBIN_PARTITION_FLAGS_LINK_VALUE_BITS;
         }
-        if (p.contains("name")) { new_p.name = p["name"]; new_p.flags |= PICOBIN_PARTITION_FLAGS_HAS_NAME_BITS; }
+        if (p.contains("name")) {
+            new_p.name = p["name"];
+            new_p.flags |= PICOBIN_PARTITION_FLAGS_HAS_NAME_BITS;
+            if (new_p.name.size() > 127) {
+                fail(ERROR_INCOMPATIBLE, "Partition name \"%s\" is %d characters long - max length is 127 characters\n", new_p.name.c_str(), new_p.name.size());
+            }
+        }
         if (p.contains("id")) {
             if (get_json_int(p["id"], new_p.id)) {new_p.flags |= PICOBIN_PARTITION_FLAGS_HAS_ID_BITS;}
             else {string p_id = p["id"]; fail(ERROR_INCOMPATIBLE, "Partition ID \"%s\" is not a valid 64bit integer\n", p_id.c_str());}


### PR DESCRIPTION
Don't add a `hash_def` item when not signing/hashing (currently it's added whenever `picotool seal` is invoked)

Validate that the partition name is < 128 characters long when creating partitions, as the size must fit within 7 bits