### PR TITLE
Update Bazel rules_libusb to 0.1.0-rc2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "2.1.2-develop",
 )
 
-bazel_dep(name = "rules_libusb", version = "0.1.0-rc1")
+bazel_dep(name = "rules_libusb", version = "0.1.0-rc2")
 bazel_dep(name = "pico-sdk", version = "2.1.0")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")


### PR DESCRIPTION
This includes some fixes to link issues on Linux that others have hit.