### PR TITLE
Ignore other blocks when signing with rollback version

### DIFF
--- a/bintool/bintool.cpp
+++ b/bintool/bintool.cpp
@@ -254,7 +254,7 @@ void set_next_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::uniqu
 }
 
 
-block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool ignore_others) {
+block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool set_others_ignored) {
     uint32_t highest_ram_address = 0;
     uint32_t highest_flash_address = 0;
     bool no_flash = false;
@@ -289,10 +289,10 @@ block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool i
         set_next_block(elf, first_block, highest_address);
         loop_start_rel = -first_block->next_block_rel;
         new_block_addr = first_block->physical_addr + first_block->next_block_rel;
-        if (ignore_others) set_block_ignored(elf, first_block->physical_addr);
+        if (set_others_ignored) set_block_ignored(elf, first_block->physical_addr);
     } else {
         DEBUG_LOG("There is already a block loop\n");
-        if (ignore_others) set_block_ignored(elf, first_block->physical_addr);
+        if (set_others_ignored) set_block_ignored(elf, first_block->physical_addr);
         uint32_t next_block_addr = first_block->physical_addr + first_block->next_block_rel;
         while (true) {
             auto segment = elf->segment_from_physical_address(next_block_addr);
@@ -326,7 +326,7 @@ block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool i
                 break;
             } else {
                 DEBUG_LOG("Continue looping\n");
-                if (ignore_others) set_block_ignored(elf, new_first_block->physical_addr);
+                if (set_others_ignored) set_block_ignored(elf, new_first_block->physical_addr);
                 next_block_addr = new_first_block->physical_addr + new_first_block->next_block_rel;
                 new_first_block.reset();
             }
@@ -426,7 +426,7 @@ std::unique_ptr<block> get_last_block(std::vector<uint8_t> &bin, uint32_t storag
 }
 
 
-block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, bool ignore_others) {
+block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, bool set_others_ignored) {
     uint32_t highest_ram_address = 0;
     uint32_t highest_flash_address = 0;
     bool no_flash = false;
@@ -458,12 +458,12 @@ block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::uni
         set_next_block(bin, storage_addr, first_block, highest_address);
         loop_start_rel = -first_block->next_block_rel;
         new_block_addr = first_block->physical_addr + first_block->next_block_rel;
-        if (ignore_others) set_block_ignored(bin, storage_addr, first_block->physical_addr);
+        if (set_others_ignored) set_block_ignored(bin, storage_addr, first_block->physical_addr);
     } else {
         DEBUG_LOG("Ooh, there is already a block loop - lets find it's end\n");
         auto all_blocks = get_all_blocks(bin, storage_addr, first_block);
         for (auto &block : all_blocks) {
-            if (ignore_others) set_block_ignored(bin, storage_addr, block->physical_addr);
+            if (set_others_ignored) set_block_ignored(bin, storage_addr, block->physical_addr);
         }
         new_first_block = std::move(all_blocks.back());
         set_next_block(bin, storage_addr, new_first_block, highest_address);

--- a/bintool/bintool.cpp
+++ b/bintool/bintool.cpp
@@ -192,7 +192,22 @@ std::unique_ptr<block> find_first_block(std::vector<uint8_t> bin, uint32_t stora
 }
 
 
-void set_next_block(elf_file *elf, std::unique_ptr<block> &first_block, uint32_t highest_address, bool ignore_first=false) {
+void set_block_ignored(elf_file *elf, uint32_t block_addr) {
+    auto seg = elf->segment_from_physical_address(block_addr);
+    if (seg == nullptr) {
+        fail(ERROR_NOT_POSSIBLE, "The ELF file does not contain the block address %x", block_addr);
+    }
+    std::vector<uint8_t> content = elf->content(*seg);
+    uint32_t offset = block_addr + 4 - seg->physical_address();
+    if ((content[offset] & 0x7f) != PICOBIN_BLOCK_ITEM_PARTITION_TABLE) {
+        DEBUG_LOG("setting block at %08x to ignored\n", block_addr);
+        content[offset] = 0x7e;   
+    }
+    elf->content(*seg, content);
+}
+
+
+void set_next_block(elf_file *elf, std::unique_ptr<block> &first_block, uint32_t highest_address) {
     // todo this isn't right, but virtual should be physical for now
     auto seg = elf->segment_from_physical_address(first_block->physical_addr);
     if (seg == nullptr) {
@@ -210,18 +225,20 @@ void set_next_block(elf_file *elf, std::unique_ptr<block> &first_block, uint32_t
         (int)first_block->physical_addr + first_block->next_block_rel_index * 4,
         (int)(highest_address));
     first_block->next_block_rel = delta;
-
-    if (ignore_first) {
-        // Set the first block as ignored
-        uint32_t image_type_offset = first_block->physical_addr + 4 - seg->physical_address();
-        content[image_type_offset] = 0x7e;
-    }
-
     elf->content(*seg, content);
 }
 
 
-void set_next_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, uint32_t highest_address, bool ignore_first=false) {
+void set_block_ignored(std::vector<uint8_t> &bin, uint32_t storage_addr, uint32_t block_addr) {
+    uint32_t offset = block_addr + 4 - storage_addr;
+    if ((bin[offset] & 0x7f) != PICOBIN_BLOCK_ITEM_PARTITION_TABLE) {
+        DEBUG_LOG("setting block at %08x to ignored\n", block_addr);
+        bin[offset] = 0x7e;   
+    }
+}
+
+
+void set_next_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, uint32_t highest_address) {
     // todo this isn't right, but virtual should be physical for now
     uint32_t offset = first_block->physical_addr + first_block->next_block_rel_index * 4 - storage_addr;
     uint32_t delta = highest_address - first_block->physical_addr;
@@ -234,16 +251,10 @@ void set_next_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::uniqu
         (int)first_block->physical_addr + first_block->next_block_rel_index * 4,
         (int)(highest_address));
     first_block->next_block_rel = delta;
-
-    if (ignore_first) {
-        // Set the first block as ignored
-        uint32_t image_type_offset = first_block->physical_addr + 4 - storage_addr;
-        bin[image_type_offset] = 0x7e;
-    }
 }
 
 
-block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool ignore_first) {
+block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool ignore_others) {
     uint32_t highest_ram_address = 0;
     uint32_t highest_flash_address = 0;
     bool no_flash = false;
@@ -275,11 +286,13 @@ block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool i
     uint32_t new_block_addr = 0;
     std::unique_ptr<block> new_first_block;
     if (!first_block->next_block_rel) {
-        set_next_block(elf, first_block, highest_address, ignore_first);
+        set_next_block(elf, first_block, highest_address);
         loop_start_rel = -first_block->next_block_rel;
         new_block_addr = first_block->physical_addr + first_block->next_block_rel;
+        if (ignore_others) set_block_ignored(elf, first_block->physical_addr);
     } else {
         DEBUG_LOG("There is already a block loop\n");
+        if (ignore_others) set_block_ignored(elf, first_block->physical_addr);
         uint32_t next_block_addr = first_block->physical_addr + first_block->next_block_rel;
         while (true) {
             auto segment = elf->segment_from_physical_address(next_block_addr);
@@ -313,11 +326,12 @@ block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool i
                 break;
             } else {
                 DEBUG_LOG("Continue looping\n");
+                if (ignore_others) set_block_ignored(elf, new_first_block->physical_addr);
                 next_block_addr = new_first_block->physical_addr + new_first_block->next_block_rel;
                 new_first_block.reset();
             }
         }
-        set_next_block(elf, new_first_block, highest_address, ignore_first);
+        set_next_block(elf, new_first_block, highest_address);
         new_block_addr = new_first_block->physical_addr + new_first_block->next_block_rel;
         loop_start_rel = first_block->physical_addr - new_block_addr;
     }
@@ -412,7 +426,7 @@ std::unique_ptr<block> get_last_block(std::vector<uint8_t> &bin, uint32_t storag
 }
 
 
-block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, bool ignore_first) {
+block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, bool ignore_others) {
     uint32_t highest_ram_address = 0;
     uint32_t highest_flash_address = 0;
     bool no_flash = false;
@@ -441,13 +455,18 @@ block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::uni
     uint32_t new_block_addr = 0;
     std::unique_ptr<block> new_first_block;
     if (!first_block->next_block_rel) {
-        set_next_block(bin, storage_addr, first_block, highest_address, ignore_first);
+        set_next_block(bin, storage_addr, first_block, highest_address);
         loop_start_rel = -first_block->next_block_rel;
         new_block_addr = first_block->physical_addr + first_block->next_block_rel;
+        if (ignore_others) set_block_ignored(bin, storage_addr, first_block->physical_addr);
     } else {
         DEBUG_LOG("Ooh, there is already a block loop - lets find it's end\n");
-        new_first_block = get_last_block(bin, storage_addr, first_block);
-        set_next_block(bin, storage_addr, new_first_block, highest_address, ignore_first);
+        auto all_blocks = get_all_blocks(bin, storage_addr, first_block);
+        for (auto &block : all_blocks) {
+            if (ignore_others) set_block_ignored(bin, storage_addr, block->physical_addr);
+        }
+        new_first_block = std::move(all_blocks.back());
+        set_next_block(bin, storage_addr, new_first_block, highest_address);
         new_block_addr = new_first_block->physical_addr + new_first_block->next_block_rel;
         loop_start_rel = first_block->physical_addr - new_block_addr;
     }

--- a/bintool/bintool.cpp
+++ b/bintool/bintool.cpp
@@ -192,7 +192,7 @@ std::unique_ptr<block> find_first_block(std::vector<uint8_t> bin, uint32_t stora
 }
 
 
-void set_next_block(elf_file *elf, std::unique_ptr<block> &first_block, uint32_t highest_address) {
+void set_next_block(elf_file *elf, std::unique_ptr<block> &first_block, uint32_t highest_address, bool ignore_first=false) {
     // todo this isn't right, but virtual should be physical for now
     auto seg = elf->segment_from_physical_address(first_block->physical_addr);
     if (seg == nullptr) {
@@ -210,11 +210,18 @@ void set_next_block(elf_file *elf, std::unique_ptr<block> &first_block, uint32_t
         (int)first_block->physical_addr + first_block->next_block_rel_index * 4,
         (int)(highest_address));
     first_block->next_block_rel = delta;
+
+    if (ignore_first) {
+        // Set the first block as ignored
+        uint32_t image_type_offset = first_block->physical_addr + 4 - seg->physical_address();
+        content[image_type_offset] = 0x7e;
+    }
+
     elf->content(*seg, content);
 }
 
 
-void set_next_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, uint32_t highest_address) {
+void set_next_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, uint32_t highest_address, bool ignore_first=false) {
     // todo this isn't right, but virtual should be physical for now
     uint32_t offset = first_block->physical_addr + first_block->next_block_rel_index * 4 - storage_addr;
     uint32_t delta = highest_address - first_block->physical_addr;
@@ -227,10 +234,16 @@ void set_next_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::uniqu
         (int)first_block->physical_addr + first_block->next_block_rel_index * 4,
         (int)(highest_address));
     first_block->next_block_rel = delta;
+
+    if (ignore_first) {
+        // Set the first block as ignored
+        uint32_t image_type_offset = first_block->physical_addr + 4 - storage_addr;
+        bin[image_type_offset] = 0x7e;
+    }
 }
 
 
-block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block) {
+block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool ignore_first) {
     uint32_t highest_ram_address = 0;
     uint32_t highest_flash_address = 0;
     bool no_flash = false;
@@ -262,7 +275,7 @@ block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block) {
     uint32_t new_block_addr = 0;
     std::unique_ptr<block> new_first_block;
     if (!first_block->next_block_rel) {
-        set_next_block(elf, first_block, highest_address);
+        set_next_block(elf, first_block, highest_address, ignore_first);
         loop_start_rel = -first_block->next_block_rel;
         new_block_addr = first_block->physical_addr + first_block->next_block_rel;
     } else {
@@ -304,7 +317,7 @@ block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block) {
                 new_first_block.reset();
             }
         }
-        set_next_block(elf, new_first_block, highest_address);
+        set_next_block(elf, new_first_block, highest_address, ignore_first);
         new_block_addr = new_first_block->physical_addr + new_first_block->next_block_rel;
         loop_start_rel = first_block->physical_addr - new_block_addr;
     }
@@ -399,7 +412,7 @@ std::unique_ptr<block> get_last_block(std::vector<uint8_t> &bin, uint32_t storag
 }
 
 
-block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block) {
+block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, bool ignore_first) {
     uint32_t highest_ram_address = 0;
     uint32_t highest_flash_address = 0;
     bool no_flash = false;
@@ -428,13 +441,13 @@ block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::uni
     uint32_t new_block_addr = 0;
     std::unique_ptr<block> new_first_block;
     if (!first_block->next_block_rel) {
-        set_next_block(bin, storage_addr, first_block, highest_address);
+        set_next_block(bin, storage_addr, first_block, highest_address, ignore_first);
         loop_start_rel = -first_block->next_block_rel;
         new_block_addr = first_block->physical_addr + first_block->next_block_rel;
     } else {
         DEBUG_LOG("Ooh, there is already a block loop - lets find it's end\n");
         new_first_block = get_last_block(bin, storage_addr, first_block);
-        set_next_block(bin, storage_addr, new_first_block, highest_address);
+        set_next_block(bin, storage_addr, new_first_block, highest_address, ignore_first);
         new_block_addr = new_first_block->physical_addr + new_first_block->next_block_rel;
         loop_start_rel = first_block->physical_addr - new_block_addr;
     }

--- a/bintool/bintool.h
+++ b/bintool/bintool.h
@@ -22,7 +22,7 @@ typedef enum verified_t {
 
 // Elfs
 std::unique_ptr<block> find_first_block(elf_file *elf);
-block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool ignore_first=false);
+block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool ignore_others=false);
 #if HAS_MBEDTLS
     int hash_andor_sign(elf_file *elf, block *new_block, const public_t public_key, const private_t private_key, bool hash_value, bool sign, bool clear_sram = false);
     void encrypt_guts(elf_file *elf, block *new_block, const aes_key_t aes_key, std::vector<uint8_t> &iv_data, std::vector<uint8_t> &enc_data);
@@ -34,7 +34,7 @@ typedef std::function<void(std::vector<uint8_t> &bin, uint32_t offset, uint32_t 
 std::unique_ptr<block> find_first_block(std::vector<uint8_t> bin, uint32_t storage_addr);
 std::unique_ptr<block> get_last_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, get_more_bin_cb more_cb = nullptr);
 std::vector<std::unique_ptr<block>> get_all_blocks(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, get_more_bin_cb more_cb = nullptr);
-block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, bool ignore_first=false);
+block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, bool ignore_others=false);
 uint32_t calc_checksum(std::vector<uint8_t> bin);
 #if HAS_MBEDTLS
     std::vector<uint8_t> hash_andor_sign(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *new_block, const public_t public_key, const private_t private_key, bool hash_value, bool sign, bool clear_sram = false);

--- a/bintool/bintool.h
+++ b/bintool/bintool.h
@@ -22,7 +22,7 @@ typedef enum verified_t {
 
 // Elfs
 std::unique_ptr<block> find_first_block(elf_file *elf);
-block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block);
+block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool ignore_first=false);
 #if HAS_MBEDTLS
     int hash_andor_sign(elf_file *elf, block *new_block, const public_t public_key, const private_t private_key, bool hash_value, bool sign, bool clear_sram = false);
     void encrypt_guts(elf_file *elf, block *new_block, const aes_key_t aes_key, std::vector<uint8_t> &iv_data, std::vector<uint8_t> &enc_data);
@@ -34,7 +34,7 @@ typedef std::function<void(std::vector<uint8_t> &bin, uint32_t offset, uint32_t 
 std::unique_ptr<block> find_first_block(std::vector<uint8_t> bin, uint32_t storage_addr);
 std::unique_ptr<block> get_last_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, get_more_bin_cb more_cb = nullptr);
 std::vector<std::unique_ptr<block>> get_all_blocks(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, get_more_bin_cb more_cb = nullptr);
-block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block);
+block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, bool ignore_first=false);
 uint32_t calc_checksum(std::vector<uint8_t> bin);
 #if HAS_MBEDTLS
     std::vector<uint8_t> hash_andor_sign(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *new_block, const public_t public_key, const private_t private_key, bool hash_value, bool sign, bool clear_sram = false);

--- a/bintool/bintool.h
+++ b/bintool/bintool.h
@@ -22,7 +22,7 @@ typedef enum verified_t {
 
 // Elfs
 std::unique_ptr<block> find_first_block(elf_file *elf);
-block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool ignore_others=false);
+block place_new_block(elf_file *elf, std::unique_ptr<block> &first_block, bool set_others_ignored=false);
 #if HAS_MBEDTLS
     int hash_andor_sign(elf_file *elf, block *new_block, const public_t public_key, const private_t private_key, bool hash_value, bool sign, bool clear_sram = false);
     void encrypt_guts(elf_file *elf, block *new_block, const aes_key_t aes_key, std::vector<uint8_t> &iv_data, std::vector<uint8_t> &enc_data);
@@ -34,7 +34,7 @@ typedef std::function<void(std::vector<uint8_t> &bin, uint32_t offset, uint32_t 
 std::unique_ptr<block> find_first_block(std::vector<uint8_t> bin, uint32_t storage_addr);
 std::unique_ptr<block> get_last_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, get_more_bin_cb more_cb = nullptr);
 std::vector<std::unique_ptr<block>> get_all_blocks(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, get_more_bin_cb more_cb = nullptr);
-block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, bool ignore_others=false);
+block place_new_block(std::vector<uint8_t> &bin, uint32_t storage_addr, std::unique_ptr<block> &first_block, bool set_others_ignored=false);
 uint32_t calc_checksum(std::vector<uint8_t> bin);
 #if HAS_MBEDTLS
     std::vector<uint8_t> hash_andor_sign(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *new_block, const public_t public_key, const private_t private_key, bool hash_value, bool sign, bool clear_sram = false);

--- a/bintool/metadata.h
+++ b/bintool/metadata.h
@@ -208,7 +208,7 @@ struct partition_table_item : public single_byte_size_item {
             }
             if (name.size() > 0) {
                 char size = name.size();
-                assert(size & 0x7f == size);
+                assert((size & 0x7f) == size);
                 std::vector<char> name_vec = {size};
                 for (char c : name) {
                     name_vec.push_back(c);

--- a/main.cpp
+++ b/main.cpp
@@ -4914,7 +4914,7 @@ void sign_guts_elf(elf_file* elf, private_t private_key, public_t public_key) {
         }
     }
 
-    // Workaround RP2350-E13, which means when using rollback versions, all other blocks must be ignored
+    // Workaround RP2350-E13, which means when using rollback versions, all other blocks must be set as ignored
     block new_block = place_new_block(elf, first_block, settings.seal.rollback_version);
 
     if (settings.seal.set_tbyb) {
@@ -5001,7 +5001,7 @@ vector<uint8_t> sign_guts_bin(iostream_memory_access in, private_t private_key, 
         }
     }
 
-    // Workaround RP2350-E13, which means when using rollback versions, all other blocks must be ignored
+    // Workaround RP2350-E13, which means when using rollback versions, all other blocks must be set as ignored
     block new_block = place_new_block(bin, bin_start, first_block, settings.seal.rollback_version);
 
     if (settings.seal.major_version || settings.seal.minor_version || settings.seal.rollback_version) {

--- a/main.cpp
+++ b/main.cpp
@@ -4914,7 +4914,8 @@ void sign_guts_elf(elf_file* elf, private_t private_key, public_t public_key) {
         }
     }
 
-    block new_block = place_new_block(elf, first_block);
+    // Workaround RP2350-E13, which means when using rollback versions, first block must be ignored
+    block new_block = place_new_block(elf, first_block, settings.seal.rollback_version);
 
     if (settings.seal.set_tbyb) {
         // Set the TBYB bit on the image_type_item
@@ -5000,7 +5001,8 @@ vector<uint8_t> sign_guts_bin(iostream_memory_access in, private_t private_key, 
         }
     }
 
-    block new_block = place_new_block(bin, bin_start, first_block);
+    // Workaround RP2350-E13, which means when using rollback versions, first block must be ignored
+    block new_block = place_new_block(bin, bin_start, first_block, settings.seal.rollback_version);
 
     if (settings.seal.major_version || settings.seal.minor_version || settings.seal.rollback_version) {
         std::shared_ptr<version_item> version = new_block.get_item<version_item>();

--- a/main.cpp
+++ b/main.cpp
@@ -4914,7 +4914,7 @@ void sign_guts_elf(elf_file* elf, private_t private_key, public_t public_key) {
         }
     }
 
-    // Workaround RP2350-E13, which means when using rollback versions, first block must be ignored
+    // Workaround RP2350-E13, which means when using rollback versions, all other blocks must be ignored
     block new_block = place_new_block(elf, first_block, settings.seal.rollback_version);
 
     if (settings.seal.set_tbyb) {
@@ -5001,7 +5001,7 @@ vector<uint8_t> sign_guts_bin(iostream_memory_access in, private_t private_key, 
         }
     }
 
-    // Workaround RP2350-E13, which means when using rollback versions, first block must be ignored
+    // Workaround RP2350-E13, which means when using rollback versions, all other blocks must be ignored
     block new_block = place_new_block(bin, bin_start, first_block, settings.seal.rollback_version);
 
     if (settings.seal.major_version || settings.seal.minor_version || settings.seal.rollback_version) {


### PR DESCRIPTION
This sets any other blocks (other than partition tables) as ignored blocks when signing with a rollback version, to avoid hitting RP2350-E13

Bug was raised in https://forums.raspberrypi.com/viewtopic.php?t=388370