### PR TITLE
Make no libusb build clearer

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,7 +8,7 @@ git submodule update --init lib/mbedtls
 
 You also need to install `libusb-1.0` if you want to use the USB functionality.
 
-> If libusb-1.0 is not installed, picotool still builds, but it omits all options that deal with managing a pico via USB (load, save, erase, verify, reboot). Builds that do not include USB support can be recognized because these commands won't appear in the output of the help command. The build output message `libUSB is not found - no USB support will be built` also appears in the build logs, and if you attempt to execute an invalid command you get the error `This version of picotool was compiled without USB support. Some commands are not available.`.
+> If libusb-1.0 is not installed, picotool still builds, but it omits all options that deal with managing a pico via USB (load, save, erase, verify, reboot). Builds that do not include USB support can be recognized because these commands won't appear in the output of the help command, and if you attempt to execute an invalid command you get the error `This version of picotool was compiled without USB support. Some commands are not available.`. The build output message `libUSB is not found - no USB support will be built` also appears in the build logs.
 
 ### Linux / macOS
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,7 +8,7 @@ git submodule update --init lib/mbedtls
 
 You also need to install `libusb-1.0` if you want to use the USB functionality.
 
-> If libusb-1.0 is not installed, picotool still builds, but it omits all options that deal with managing a pico via USB (load, save, erase, verify, reboot). Builds that do not include USB support can be recognized because these commands won't appear in the output of the help command, and if you attempt to execute an invalid command you get the error `This version of picotool was compiled without USB support. Some commands are not available.`. The build output message `libUSB is not found - no USB support will be built` also appears in the build logs.
+> If libusb-1.0 is not installed, picotool still builds, but it omits all options that deal with managing a pico via USB (load, save, erase, verify, reboot). Builds that do not include USB support can be identified by running `picotool version`, which will state `This version of picotool was compiled without USB support. Some commands are not available.`. Additionally, the unsupported commands won't appear in the output of the help command, and if you attempt to execute an invalid command you will get an error message. The build output message `libUSB is not found - no USB support will be built` also appears in the build logs.
 
 ### Linux / macOS
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,7 +8,7 @@ git submodule update --init lib/mbedtls
 
 You also need to install `libusb-1.0` if you want to use the USB functionality.
 
-> If libusb-1.0 is not installed, picotool still builds, but it omits all options that deal with managing a pico via USB (load, save, erase, verify, reboot). Builds that do not include USB support can be recognized because these commands won't appear in the output of the help command. The build output message 'libUSB is not found - no USB support will be built' also appears in the build logs.
+> If libusb-1.0 is not installed, picotool still builds, but it omits all options that deal with managing a pico via USB (load, save, erase, verify, reboot). Builds that do not include USB support can be recognized because these commands won't appear in the output of the help command. The build output message `libUSB is not found - no USB support will be built` also appears in the build logs, and if you attempt to execute an invalid command you get the error `This version of picotool was compiled without USB support. Some commands are not available.`.
 
 ### Linux / macOS
 

--- a/main.cpp
+++ b/main.cpp
@@ -705,7 +705,11 @@ struct info_command : public cmd {
     }
 
     string get_doc() const override {
+        #if HAS_LIBUSB
         return "Display information from the target device(s) or file.\nWithout any arguments, this will display basic information for all connected RP-series devices in BOOTSEL mode";
+        #else
+        return "Display information from the target file.";
+        #endif
     }
 };
 
@@ -736,7 +740,11 @@ struct config_command : public cmd {
     }
 
     string get_doc() const override {
+        #if HAS_LIBUSB
         return "Display or change program configuration settings from the target device(s) or file.";
+        #else
+        return "Display or change program configuration settings from the target file.";
+        #endif
     }
 };
 
@@ -1376,8 +1384,12 @@ struct version_command : public cmd {
     bool execute(device_map &devices) override {
         if (settings.version.semantic)
             std::cout << PICOTOOL_VERSION << "\n";
-        else
+        else {
             std::cout << "picotool v" << PICOTOOL_VERSION << " (" << SYSTEM_VERSION << ", " << COMPILER_INFO << ")\n";
+            #if !HAS_LIBUSB
+            std::cout << "\nThis version of picotool was compiled without USB support. Some commands are not available.\n";
+            #endif
+        }
         if (!settings.version.version.empty()) {
             string picotool_v = string(PICOTOOL_VERSION);
             picotool_v = picotool_v.substr(0, picotool_v.find("-"));
@@ -1623,6 +1635,9 @@ int parse(const int argc, char **argv) {
             } else {
                 fos << string("Use \"picotool help ").append(selected_cmd->name()).append("\" for more info\n");
             }
+            #if !HAS_LIBUSB
+            fos << string("\nThis version of picotool was compiled without USB support. Some commands are not available.\n");
+            #endif
         } else {
             cli::option_map options;
             selected_cmd->get_cli().get_option_help("", "", options);
@@ -1654,6 +1669,11 @@ int parse(const int argc, char **argv) {
             fos.hanging_indent(0);
             fos.wrap_hard();
             fos << "Use \"picotool help <cmd>\" for more info\n";
+            #if !HAS_LIBUSB
+            if (!help_mode) {
+                fos << "\nThis version of picotool was compiled without USB support. Some commands are not available.\n";
+            }
+            #endif
         }
         fos.flush();
     };

--- a/main.cpp
+++ b/main.cpp
@@ -115,7 +115,7 @@ static const string rp2350_arm_ns_family_name = "rp2350-arm-ns";
 static const string rp2350_riscv_family_name = "rp2350-riscv";
 
 #if !HAS_LIBUSB
-static const string libusb_not_found_message = "\nThis version of picotool was compiled without USB support. Some commands are not available.\n";
+static const string built_without_libusb_message = "\nThis version of picotool was compiled without USB support. Some commands are not available.\n";
 #endif
 
 static string hex_string(int64_t value, int width=8, bool prefix=true, bool uppercase=false) {
@@ -1391,7 +1391,7 @@ struct version_command : public cmd {
         else {
             std::cout << "picotool v" << PICOTOOL_VERSION << " (" << SYSTEM_VERSION << ", " << COMPILER_INFO << ")\n";
             #if !HAS_LIBUSB
-            std::cout << libusb_not_found_message;
+            std::cout << built_without_libusb_message;
             #endif
         }
         if (!settings.version.version.empty()) {
@@ -1640,7 +1640,7 @@ int parse(const int argc, char **argv) {
                 fos << string("Use \"picotool help ").append(selected_cmd->name()).append("\" for more info\n");
             }
             #if !HAS_LIBUSB
-            fos << libusb_not_found_message;
+            fos << built_without_libusb_message;
             #endif
         } else {
             cli::option_map options;
@@ -1675,7 +1675,7 @@ int parse(const int argc, char **argv) {
             fos << "Use \"picotool help <cmd>\" for more info\n";
             #if !HAS_LIBUSB
             if (!help_mode) {
-                fos << libusb_not_found_message;
+                fos << built_without_libusb_message;
             }
             #endif
         }

--- a/main.cpp
+++ b/main.cpp
@@ -114,6 +114,10 @@ static const string rp2350_arm_s_family_name = "rp2350-arm-s";
 static const string rp2350_arm_ns_family_name = "rp2350-arm-ns";
 static const string rp2350_riscv_family_name = "rp2350-riscv";
 
+#if !HAS_LIBUSB
+static const string libusb_not_found_message = "\nThis version of picotool was compiled without USB support. Some commands are not available.\n";
+#endif
+
 static string hex_string(int64_t value, int width=8, bool prefix=true, bool uppercase=false) {
     std::stringstream ss;
     if (prefix) ss << "0x";
@@ -1387,7 +1391,7 @@ struct version_command : public cmd {
         else {
             std::cout << "picotool v" << PICOTOOL_VERSION << " (" << SYSTEM_VERSION << ", " << COMPILER_INFO << ")\n";
             #if !HAS_LIBUSB
-            std::cout << "\nThis version of picotool was compiled without USB support. Some commands are not available.\n";
+            std::cout << libusb_not_found_message;
             #endif
         }
         if (!settings.version.version.empty()) {
@@ -1636,7 +1640,7 @@ int parse(const int argc, char **argv) {
                 fos << string("Use \"picotool help ").append(selected_cmd->name()).append("\" for more info\n");
             }
             #if !HAS_LIBUSB
-            fos << string("\nThis version of picotool was compiled without USB support. Some commands are not available.\n");
+            fos << libusb_not_found_message;
             #endif
         } else {
             cli::option_map options;
@@ -1671,7 +1675,7 @@ int parse(const int argc, char **argv) {
             fos << "Use \"picotool help <cmd>\" for more info\n";
             #if !HAS_LIBUSB
             if (!help_mode) {
-                fos << "\nThis version of picotool was compiled without USB support. Some commands are not available.\n";
+                fos << libusb_not_found_message;
             }
             #endif
         }


### PR DESCRIPTION
Fix info and config help text without libusb, add no USB support messages to command line parsing errors, and add no USB support message to `picotool version`

```
$ picotool version
picotool v2.1.2-develop (Linux, GNU-12.2.0, RelWithDebInfo)

This version of picotool was compiled without USB support. Some commands are not available.
```

Eg, the output from `picotool info` is now
```
$ picotool info

ERROR: missing <filename>

SYNOPSIS:
    picotool info [-b] [-m] [-p] [-d] [--debug] [-l] [-a] <filename> [-t <type>]

Use "picotool help info" for more info

This version of picotool was compiled without USB support. Some commands are not available.
```
or `picotool load`
```
$ picotool load

ERROR: Unknown command: load

COMMANDS:
    info        Display information from the target file.
    config      Display or change program configuration settings from the target file.
    encrypt     Encrypt the program.
    seal        Add final metadata to a binary, optionally including a hash and/or signature.
    link        Link multiple binaries into one block loop.
    otp         Commands related to the RP2350 OTP (One-Time-Programmable) Memory
    partition   Commands related to RP2350 Partition Tables
    uf2         Commands related to UF2 creation and status
    version     Display picotool version
    coprodis    Post-process coprocessor instructions in disassembly files.
    help        Show general help or help for a specific command

Use "picotool help <cmd>" for more info

This version of picotool was compiled without USB support. Some commands are not available.
```

Fixes #245 