### PR TITLE
Check hamming weights of AES key shares

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5173,13 +5173,16 @@ bool encrypt_command::execute(device_map &devices) {
         }
     }
 
+    uint8_t max_weight_delta = 1;
+
     if (!keyIsShare) {
         // Generate a random key share from 256-bit key
         std::random_device rand{};
         assert(rand.max() - rand.min() >= 256);
         for(int i=0; i < 8; i++) {
             // Regenerate the share word until the hamming weights are close to each other
-            while (true) {
+            bool pass = false;
+            for (int attempt=0; attempt < 100000; attempt++) {
                 for (int j=0; j < 12; j++) {
                     aes_key_share.bytes[i*16 + j] = rand();
                 }
@@ -5187,10 +5190,44 @@ bool encrypt_command::execute(device_map &devices) {
                                             ^ aes_key_share.words[i*4]
                                             ^ aes_key_share.words[i*4 + 1]
                                             ^ aes_key_share.words[i*4 + 2];
+
+                pass = true;
+                for (int half=0; half < 2; half++) {
+                    uint8_t max_weight = 0;
+                    uint8_t min_weight = 16;
+                    for (int j=0; j < 4; j++) {
+                        uint16_t half_word = aes_key_share.words[i*4 + j] >> half*16;
+                        uint8_t weight = __builtin_popcount(half_word);
+                        if (weight > max_weight) {
+                            max_weight = weight;
+                        }
+                        if (weight < min_weight) {
+                            min_weight = weight;
+                        }
+                    }
+                    if (max_weight - min_weight > max_weight_delta) {
+                        DEBUG_LOG("Generated share word %d half %d has hamming weights too varied - regenerating attempt %d\n", i, half, attempt);
+                        pass = false;
+                        break;
+                    }
+                }
+                if (pass) {
+                    break;
+                }
+            }
+            if (!pass) {
+                fail(ERROR_INCOMPATIBLE, "Failed to generate a share word with hamming weights within %d", max_weight_delta);
+            }
+        }
+    } else {
+        // Check the share word hamming weights are close to each other
+        for(int i=0; i < 8; i++) {
+            for (int half=0; half < 2; half++) {
                 uint8_t max_weight = 0;
-                uint8_t min_weight = 32;
+                uint8_t min_weight = 16;
                 for (int j=0; j < 4; j++) {
-                    uint8_t weight = __builtin_popcount(aes_key_share.words[i*4 + j]);
+                    uint16_t half_word = aes_key_share.words[i*4 + j] >> half*16;
+                    uint8_t weight = __builtin_popcount(half_word);
                     if (weight > max_weight) {
                         max_weight = weight;
                     }
@@ -5198,29 +5235,9 @@ bool encrypt_command::execute(device_map &devices) {
                         min_weight = weight;
                     }
                 }
-                if (max_weight - min_weight <= 4) {
-                    break;
-                } else {
-                    DEBUG_LOG("Generated share word %d has hamming weights too varied - regenerating\n", i);
+                if (max_weight - min_weight > max_weight_delta) {
+                    std::cout << "WARNING: Key Share Word " << i << " half " << half << " has hamming weights too varied - this may leak information about the key\n";
                 }
-            }
-        }
-    } else {
-        // Check the share word hamming weights are close to each other
-        for(int i=0; i < 8; i++) {
-            uint8_t max_weight = 0;
-            uint8_t min_weight = 32;
-            for (int j=0; j < 4; j++) {
-                uint8_t weight = __builtin_popcount(aes_key_share.words[i*4 + j]);
-                if (weight > max_weight) {
-                    max_weight = weight;
-                }
-                if (weight < min_weight) {
-                    min_weight = weight;
-                }
-            }
-            if (max_weight - min_weight > 4) {
-                std::cout << "Key Share Word " << i << " has hamming weights too varied - this may leak information about the key\n";
             }
         }
     }

--- a/main.cpp
+++ b/main.cpp
@@ -5173,13 +5173,15 @@ bool encrypt_command::execute(device_map &devices) {
         }
     }
 
+    uint8_t max_weight_delta = 1;
+
     if (!keyIsShare) {
         // Generate a random key share from 256-bit key
         std::random_device rand{};
         assert(rand.max() - rand.min() >= 256);
-        for(int i=0; i < 8; i++) {
-            // Regenerate the share word until the hamming weights are close to each other
-            while (true) {
+        // Regenerate the shares until the hamming weights are close to each other
+        while (true) {
+            for(int i=0; i < 8; i++) {
                 for (int j=0; j < 12; j++) {
                     aes_key_share.bytes[i*16 + j] = rand();
                 }
@@ -5187,31 +5189,15 @@ bool encrypt_command::execute(device_map &devices) {
                                             ^ aes_key_share.words[i*4]
                                             ^ aes_key_share.words[i*4 + 1]
                                             ^ aes_key_share.words[i*4 + 2];
-                uint8_t max_weight = 0;
-                uint8_t min_weight = 32;
-                for (int j=0; j < 4; j++) {
-                    uint8_t weight = __builtin_popcount(aes_key_share.words[i*4 + j]);
-                    if (weight > max_weight) {
-                        max_weight = weight;
-                    }
-                    if (weight < min_weight) {
-                        min_weight = weight;
-                    }
-                }
-                if (max_weight - min_weight <= 4) {
-                    break;
-                } else {
-                    printf("Generated share word %d has hamming weights too varied - regenerating\n", i);
-                }
             }
-        }
-    } else {
-        // Check the share word hamming weights are close to each other
-        for(int i=0; i < 8; i++) {
+
             uint8_t max_weight = 0;
-            uint8_t min_weight = 32;
-            for (int j=0; j < 4; j++) {
-                uint8_t weight = __builtin_popcount(aes_key_share.words[i*4 + j]);
+            uint8_t min_weight = 128;
+            for (int i=0; i < 4; i++) {
+                uint8_t weight = 0;
+                for (int j=0; j < 4; j++) {
+                    weight += __builtin_popcount(aes_key_share.words[i + j*4]);
+                }
                 if (weight > max_weight) {
                     max_weight = weight;
                 }
@@ -5219,9 +5205,31 @@ bool encrypt_command::execute(device_map &devices) {
                     min_weight = weight;
                 }
             }
-            if (max_weight - min_weight > 4) {
-                std::cout << "Key Share Word " << i << " has hamming weights too varied - this may leak information about the key\n";
+            if (max_weight - min_weight <= max_weight_delta) {
+                break;
+            } else {
+                printf("Generated shares have hamming weights too varied %d - regenerating\n", max_weight - min_weight);
             }
+        }
+    } else {
+        // Check the share hamming weights are close to each other
+        uint8_t max_weight = 0;
+        uint8_t min_weight = 128;
+        for (int i=0; i < 4; i++) {
+            uint8_t weight = 0;
+            for (int j=0; j < 4; j++) {
+                weight += __builtin_popcount(aes_key_share.words[i + j*4]);
+            }
+            if (weight > max_weight) {
+                max_weight = weight;
+            }
+            if (weight < min_weight) {
+                min_weight = weight;
+            }
+        }
+
+        if (max_weight - min_weight > max_weight_delta) {
+            std::cout << "WARNING: Key Shares have hamming weights too varied (" << (int)max_weight << " -> " << (int)min_weight << ") - this may leak information about the key\n";
         }
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -5173,15 +5173,13 @@ bool encrypt_command::execute(device_map &devices) {
         }
     }
 
-    uint8_t max_weight_delta = 1;
-
     if (!keyIsShare) {
         // Generate a random key share from 256-bit key
         std::random_device rand{};
         assert(rand.max() - rand.min() >= 256);
-        // Regenerate the shares until the hamming weights are close to each other
-        while (true) {
-            for(int i=0; i < 8; i++) {
+        for(int i=0; i < 8; i++) {
+            // Regenerate the share word until the hamming weights are close to each other
+            while (true) {
                 for (int j=0; j < 12; j++) {
                     aes_key_share.bytes[i*16 + j] = rand();
                 }
@@ -5189,15 +5187,31 @@ bool encrypt_command::execute(device_map &devices) {
                                             ^ aes_key_share.words[i*4]
                                             ^ aes_key_share.words[i*4 + 1]
                                             ^ aes_key_share.words[i*4 + 2];
-            }
-
-            uint8_t max_weight = 0;
-            uint8_t min_weight = 128;
-            for (int i=0; i < 4; i++) {
-                uint8_t weight = 0;
+                uint8_t max_weight = 0;
+                uint8_t min_weight = 32;
                 for (int j=0; j < 4; j++) {
-                    weight += __builtin_popcount(aes_key_share.words[i + j*4]);
+                    uint8_t weight = __builtin_popcount(aes_key_share.words[i*4 + j]);
+                    if (weight > max_weight) {
+                        max_weight = weight;
+                    }
+                    if (weight < min_weight) {
+                        min_weight = weight;
+                    }
                 }
+                if (max_weight - min_weight <= 4) {
+                    break;
+                } else {
+                    DEBUG_LOG("Generated share word %d has hamming weights too varied - regenerating\n", i);
+                }
+            }
+        }
+    } else {
+        // Check the share word hamming weights are close to each other
+        for(int i=0; i < 8; i++) {
+            uint8_t max_weight = 0;
+            uint8_t min_weight = 32;
+            for (int j=0; j < 4; j++) {
+                uint8_t weight = __builtin_popcount(aes_key_share.words[i*4 + j]);
                 if (weight > max_weight) {
                     max_weight = weight;
                 }
@@ -5205,31 +5219,9 @@ bool encrypt_command::execute(device_map &devices) {
                     min_weight = weight;
                 }
             }
-            if (max_weight - min_weight <= max_weight_delta) {
-                break;
-            } else {
-                DEBUG_LOG("Generated shares have hamming weights too varied %d - regenerating\n", max_weight - min_weight);
+            if (max_weight - min_weight > 4) {
+                std::cout << "Key Share Word " << i << " has hamming weights too varied - this may leak information about the key\n";
             }
-        }
-    } else {
-        // Check the share hamming weights are close to each other
-        uint8_t max_weight = 0;
-        uint8_t min_weight = 128;
-        for (int i=0; i < 4; i++) {
-            uint8_t weight = 0;
-            for (int j=0; j < 4; j++) {
-                weight += __builtin_popcount(aes_key_share.words[i + j*4]);
-            }
-            if (weight > max_weight) {
-                max_weight = weight;
-            }
-            if (weight < min_weight) {
-                min_weight = weight;
-            }
-        }
-
-        if (max_weight - min_weight > max_weight_delta) {
-            std::cout << "WARNING: Key Shares have hamming weights too varied (" << (int)max_weight << " -> " << (int)min_weight << ") - this may leak information about the key\n";
         }
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -5178,13 +5178,50 @@ bool encrypt_command::execute(device_map &devices) {
         std::random_device rand{};
         assert(rand.max() - rand.min() >= 256);
         for(int i=0; i < 8; i++) {
-            for (int j=0; j < 12; j++) {
-                aes_key_share.bytes[i*16 + j] = rand();
+            // Regenerate the share word until the hamming weights are close to each other
+            while (true) {
+                for (int j=0; j < 12; j++) {
+                    aes_key_share.bytes[i*16 + j] = rand();
+                }
+                aes_key_share.words[i*4 + 3] = aes_key.words[i]
+                                            ^ aes_key_share.words[i*4]
+                                            ^ aes_key_share.words[i*4 + 1]
+                                            ^ aes_key_share.words[i*4 + 2];
+                uint8_t max_weight = 0;
+                uint8_t min_weight = 32;
+                for (int j=0; j < 4; j++) {
+                    uint8_t weight = __builtin_popcount(aes_key_share.words[i*4 + j]);
+                    if (weight > max_weight) {
+                        max_weight = weight;
+                    }
+                    if (weight < min_weight) {
+                        min_weight = weight;
+                    }
+                }
+                if (max_weight - min_weight <= 4) {
+                    break;
+                } else {
+                    printf("Generated share word %d has hamming weights too varied - regenerating\n", i);
+                }
             }
-            aes_key_share.words[i*4 + 3] = aes_key.words[i]
-                                        ^ aes_key_share.words[i*4]
-                                        ^ aes_key_share.words[i*4 + 1]
-                                        ^ aes_key_share.words[i*4 + 2];
+        }
+    } else {
+        // Check the share word hamming weights are close to each other
+        for(int i=0; i < 8; i++) {
+            uint8_t max_weight = 0;
+            uint8_t min_weight = 32;
+            for (int j=0; j < 4; j++) {
+                uint8_t weight = __builtin_popcount(aes_key_share.words[i*4 + j]);
+                if (weight > max_weight) {
+                    max_weight = weight;
+                }
+                if (weight < min_weight) {
+                    min_weight = weight;
+                }
+            }
+            if (max_weight - min_weight > 4) {
+                std::cout << "Key Share Word " << i << " has hamming weights too varied - this may leak information about the key\n";
+            }
         }
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -5173,9 +5173,13 @@ bool encrypt_command::execute(device_map &devices) {
         }
     }
 
-    uint8_t max_weight_delta = 1;
+    int min_weight = 6;
+    int max_weight = 10;
+    int min_combined_weight = 28;
+    int max_combined_weight = 36;
 
     if (!keyIsShare) {
+        std::vector<int> num_attempts;
         // Generate a random key share from 256-bit key
         std::random_device rand{};
         assert(rand.max() - rand.min() >= 256);
@@ -5193,50 +5197,52 @@ bool encrypt_command::execute(device_map &devices) {
 
                 pass = true;
                 for (int half=0; half < 2; half++) {
-                    uint8_t max_weight = 0;
-                    uint8_t min_weight = 16;
+                    uint8_t combined_weight = 0;
                     for (int j=0; j < 4; j++) {
                         uint16_t half_word = aes_key_share.words[i*4 + j] >> half*16;
                         uint8_t weight = __builtin_popcount(half_word);
-                        if (weight > max_weight) {
-                            max_weight = weight;
+                        if (weight < min_weight || weight > max_weight) {
+                            DEBUG_LOG("Generated share %d word %d half %d has hamming weights out of range %d -> %d - regenerating attempt %d\n", j, i, half, min_weight, max_weight, attempt);
+                            pass = false;
+                            break;
                         }
-                        if (weight < min_weight) {
-                            min_weight = weight;
-                        }
+                        combined_weight += weight;
                     }
-                    if (max_weight - min_weight > max_weight_delta) {
-                        DEBUG_LOG("Generated share word %d half %d has hamming weights too varied - regenerating attempt %d\n", i, half, attempt);
+                    if (!pass) break;
+                    if (combined_weight < min_combined_weight || combined_weight > max_combined_weight) {
+                        DEBUG_LOG("Generated share word %d half %d has hamming weights out of range %d -> %d - regenerating attempt %d\n", i, half, min_combined_weight, max_combined_weight, attempt);
                         pass = false;
                         break;
                     }
                 }
                 if (pass) {
+                    num_attempts.push_back(attempt);
                     break;
                 }
             }
             if (!pass) {
-                fail(ERROR_INCOMPATIBLE, "Failed to generate a share word with hamming weights within %d", max_weight_delta);
+                fail(ERROR_INCOMPATIBLE, "Failed to generate a share word with hamming weights within %d -> %d", min_weight, max_weight);
             }
         }
+
+        DEBUG_LOG("Average number of attempts: %d\n", std::accumulate(num_attempts.begin(), num_attempts.end(), 0) / num_attempts.size());
+        DEBUG_LOG("Max number of attempts: %d\n", *std::max_element(num_attempts.begin(), num_attempts.end()));
+        DEBUG_LOG("Min number of attempts: %d\n", *std::min_element(num_attempts.begin(), num_attempts.end()));
     } else {
         // Check the share word hamming weights are close to each other
         for(int i=0; i < 8; i++) {
             for (int half=0; half < 2; half++) {
-                uint8_t max_weight = 0;
-                uint8_t min_weight = 16;
+                uint8_t combined_weight = 0;
                 for (int j=0; j < 4; j++) {
                     uint16_t half_word = aes_key_share.words[i*4 + j] >> half*16;
                     uint8_t weight = __builtin_popcount(half_word);
-                    if (weight > max_weight) {
-                        max_weight = weight;
+                    if (weight < min_weight || weight > max_weight) {
+                        std::cout << "WARNING: Key Share " << j << " Word " << i << " half " << half << " has hamming weights out of range " << min_weight << " -> " << max_weight << " - this may leak information about the key\n";
                     }
-                    if (weight < min_weight) {
-                        min_weight = weight;
-                    }
+                    combined_weight += weight;
                 }
-                if (max_weight - min_weight > max_weight_delta) {
-                    std::cout << "WARNING: Key Share Word " << i << " half " << half << " has hamming weights too varied - this may leak information about the key\n";
+                if (combined_weight < min_combined_weight || combined_weight > max_combined_weight) {
+                    std::cout << "WARNING: Key Share Word " << i << " half " << half << " has hamming weights out of range " << min_combined_weight << " -> " << max_combined_weight << " - this may leak information about the key\n";
                 }
             }
         }

--- a/main.cpp
+++ b/main.cpp
@@ -5208,7 +5208,7 @@ bool encrypt_command::execute(device_map &devices) {
             if (max_weight - min_weight <= max_weight_delta) {
                 break;
             } else {
-                printf("Generated shares have hamming weights too varied %d - regenerating\n", max_weight - min_weight);
+                DEBUG_LOG("Generated shares have hamming weights too varied %d - regenerating\n", max_weight - min_weight);
             }
         }
     } else {


### PR DESCRIPTION
This checks that the hamming weights of the shares are all similar. Currently set to a max difference of 1 between shares (`max_weight_delta`), but that can be changed before merging depending on what distance is actually required for security.