### PR TITLE
Improve forced commands for RP2040 and custom vid/pid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1660,6 +1660,7 @@ to unlock our lockout of USB MSD writes (we have turned them off so the user doe
 `picotool info` again will unlock it properly the next time (or you can reboot the device).
 
 ### Zadig
+
 To communicate with RP2040 in BOOTSEL mode on Windows, you will need to install a driver. To do this, download and run [Zadig](http://zadig.akeo.ie), select `RP2 Boot (Interface 1)` from the dropdown box and select `WinUSB` as the driver, and click on the "Install Driver" button. Wait for the installation to complete - this may take a few minutes.
 
 This is only required for RP2040.

--- a/README.md
+++ b/README.md
@@ -1658,3 +1658,8 @@ this requirement (see the [hello_usb](https://github.com/raspberrypi/pico-exampl
 If you ctrl+c out of the middle of a long operation, then libusb seems to get a bit confused, which means we aren't able
 to unlock our lockout of USB MSD writes (we have turned them off so the user doesn't step on their own toes). Simply running
 `picotool info` again will unlock it properly the next time (or you can reboot the device).
+
+### Zadig
+To communicate with RP2040 in BOOTSEL mode on Windows, you will need to install a driver. To do this, download and run [Zadig](http://zadig.akeo.ie), select `RP2 Boot (Interface 1)` from the dropdown box and select `WinUSB` as the driver, and click on the "Install Driver" button. Wait for the installation to complete - this may take a few minutes.
+
+This is only required for RP2040.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ TARGET SELECTION:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -224,7 +224,7 @@ TARGET SELECTION:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -327,7 +327,7 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -395,7 +395,7 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -471,7 +471,7 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -522,7 +522,7 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -737,7 +737,7 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -896,7 +896,7 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -997,7 +997,7 @@ TARGET SELECTION:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1059,7 +1059,7 @@ TARGET SELECTION:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1108,7 +1108,7 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1154,7 +1154,7 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1241,7 +1241,7 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1308,7 +1308,7 @@ TARGET SELECTION:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
+            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ TARGET SELECTION:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -221,6 +223,8 @@ TARGET SELECTION:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -322,6 +326,8 @@ OPTIONS:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -388,6 +394,8 @@ OPTIONS:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -462,6 +470,8 @@ OPTIONS:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -511,6 +521,8 @@ OPTIONS:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -724,6 +736,8 @@ OPTIONS:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -881,6 +895,8 @@ OPTIONS:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -980,6 +996,8 @@ TARGET SELECTION:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1040,6 +1058,8 @@ TARGET SELECTION:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1087,6 +1107,8 @@ OPTIONS:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1131,6 +1153,8 @@ OPTIONS:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1216,6 +1240,8 @@ OPTIONS:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1281,6 +1307,8 @@ TARGET SELECTION:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ TARGET SELECTION:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -224,7 +225,8 @@ TARGET SELECTION:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -327,7 +329,8 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -395,7 +398,8 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -471,7 +475,8 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -522,7 +527,8 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -737,7 +743,8 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -896,7 +903,8 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -997,7 +1005,8 @@ TARGET SELECTION:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1059,7 +1068,8 @@ TARGET SELECTION:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1108,7 +1118,8 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1154,7 +1165,8 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1241,7 +1253,8 @@ OPTIONS:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode
@@ -1308,7 +1321,8 @@ TARGET SELECTION:
         --ser <ser>
             Filter by serial number
         --rp2040
-            Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode

--- a/README.md
+++ b/README.md
@@ -612,6 +612,9 @@ OPTIONS:
             Filter by product id
         --ser <ser>
             Filter by serial number
+        --rp2040
+            Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on
+            other operating systems
         -f, --force
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be rebooted back to application mode

--- a/main.cpp
+++ b/main.cpp
@@ -8841,7 +8841,7 @@ int main(int argc, char **argv) {
                         // again is to assume it has the same serial number.
                         settings.address = -1;
                         settings.bus = -1;
-                        // also skip vid/pid filtering, as that will typically change in BOOTSEL mode
+                        // also skip vid/pid filtering, as that will typically change in BOOTSEL mode, and could be white-labelled on RP2350
                         settings.pid = -1;
                         // still filter for rpi vid/pid if we don't have a serial number, as that is an RP2040 running a no_flash binary, so will
                         // have a standard rpi vid/pid in BOOTSEL mode

--- a/main.cpp
+++ b/main.cpp
@@ -8852,11 +8852,16 @@ int main(int argc, char **argv) {
                         settings.address = -1;
                         settings.bus = -1;
                         if (settings.pid != -1 || settings.vid != -1) {
-                            // also skip vid/pid filtering, as that should change in BOOTSEL mode, and could be white-labelled on RP2350
-                            settings.pid = -1;
-                            // still filter for rpi vid/pid if we don't have a serial number, as that is an RP2040 running a no_flash binary, so will
-                            // have a standard rpi vid/pid in BOOTSEL mode
-                            settings.vid = settings.ser.empty() ? -1 : 0;   // 0 means skip vid/pid filtering entirely, -1 means filter for rpi vid/pid
+                            // vid/pid filtering was enabled, but should change in BOOTSEL mode, so needs to be disabled
+                            if (settings.ser.empty()) {
+                                // this is an RP2040 running a no_flash binary, so will have a standard RP2040 vid/pid in BOOTSEL mode
+                                settings.vid = -1; // -1 means filter for standard vid/pid
+                                settings.pid = -1;
+                            } else {
+                                // skip vid/pid filtering, as it can be white-labelled on RP2350, and we know the serial number
+                                settings.vid = 0; // 0 means skip vid/pid filtering entirely
+                                settings.pid = -1;
+                            }
                         }
                         continue;
                     }

--- a/main.cpp
+++ b/main.cpp
@@ -8729,6 +8729,11 @@ int main(int argc, char **argv) {
                             bool had_note = false;
                             fos << missing_device_string(tries>0, selected_cmd->requires_rp2350());
                             if (tries) {
+#if defined(_WIN32)
+                                if (settings.force_rp2040) {
+                                    fos << " You may need to install a driver via Zadig. See \"Getting started with Raspberry Pi Pico\" for more information.";
+                                }
+#endif
                                 fos << " It is possible the device is not responding, and will have to be manually entered into BOOTSEL mode.\n";
                                 had_note = true; // suppress "but:" in this case
                             }
@@ -8760,13 +8765,8 @@ int main(int argc, char **argv) {
                             printer(dr_vidpid_micropython,
                                     " appears to be an RP-series MicroPython device not in BOOTSEL mode.");
                             if (selected_cmd->force_requires_pre_reboot()) {
-    #if defined(_WIN32)
-                                printer(dr_vidpid_stdio_usb,
-                                        " appears to have a USB serial connection, not in BOOTSEL mode. You can force reboot into BOOTSEL mode via 'picotool reboot -f -u' first.");
-    #else
                                 printer(dr_vidpid_stdio_usb,
                                         " appears to have a USB serial connection, so consider -f (or -F) to force reboot in order to run the command.");
-    #endif
                             } else {
                                 // special case message for what is actually just reboot (the only command that doesn't require reboot first)
                                 printer(dr_vidpid_stdio_usb,
@@ -8813,6 +8813,7 @@ int main(int argc, char **argv) {
                                 libusb_get_device_descriptor(to_reboot, &desc);
                                 if (desc.idProduct == PRODUCT_ID_RP2040_STDIO_USB || settings.force_rp2040) {
                                     disable_mask = 0;   // enable MSC interface so Zadig works correctly
+                                    settings.force_rp2040 = true;
                                 }
                             }
     #endif

--- a/main.cpp
+++ b/main.cpp
@@ -8731,7 +8731,7 @@ int main(int argc, char **argv) {
                             if (tries) {
 #if defined(_WIN32)
                                 if (settings.force_rp2040) {
-                                    fos << " You may need to install a driver via Zadig. See \"Getting started with Raspberry Pi Pico\" for more information.";
+                                    fos << " You may need to install a driver via Zadig. See Zadig in the README (https://github.com/raspberrypi/picotool#zadig) for more information.";
                                 }
 #endif
                                 fos << " It is possible the device is not responding, and will have to be manually entered into BOOTSEL mode.\n";
@@ -8756,7 +8756,7 @@ int main(int argc, char **argv) {
                                     " appears to have a USB serial connection, but picotool was unable to connect. Maybe try 'sudo' or check your permissions.");
     #else
                             printer(dr_vidpid_bootrom_cant_connect,
-                                    " appears to be in BOOTSEL mode, but picotool was unable to connect. You may need to install a driver via Zadig. See \"Getting started with Raspberry Pi Pico\" for more information");
+                                    " appears to be in BOOTSEL mode, but picotool was unable to connect. You may need to install a driver via Zadig. See Zadig in the README (https://github.com/raspberrypi/picotool#zadig) for more information");
                             printer(dr_vidpid_stdio_usb_cant_connect,
                                     " appears to have a USB serial connection, but picotool was unable to connect.");
     #endif

--- a/main.cpp
+++ b/main.cpp
@@ -8841,6 +8841,11 @@ int main(int argc, char **argv) {
                         // again is to assume it has the same serial number.
                         settings.address = -1;
                         settings.bus = -1;
+                        // also skip vid/pid filtering, as that will typically change in BOOTSEL mode
+                        settings.pid = -1;
+                        // still filter for rpi vid/pid if we don't have a serial number, as that is an RP2040 running a no_flash binary, so will
+                        // have a standard rpi vid/pid in BOOTSEL mode
+                        settings.vid = settings.ser.empty() ? -1 : 0;   // 0 means skip vid/pid filtering entirely, -1 means filter for rpi vid/pid
                         continue;
                     }
                 }

--- a/main.cpp
+++ b/main.cpp
@@ -611,7 +611,7 @@ auto device_selection =
         (option("--vid") & integer("vid").set(settings.vid).if_missing([] { return "missing vid"; })) % "Filter by vendor id" +
         (option("--pid") & integer("pid").set(settings.pid)) % "Filter by product id" +
         (option("--ser") & value("ser").set(settings.ser)) % "Filter by serial number"
-        + option("--rp2040").set(settings.force_rp2040) % "Use RP2040 workarounds on Windows when using custom vid/pid (ignored on other platforms)"
+        + option("--rp2040").set(settings.force_rp2040) % "Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)"
         + option('f', "--force").set(settings.force) % "Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the command (unless the command itself is a 'reboot') the device will be rebooted back to application mode" +
                 option('F', "--force-no-reboot").set(settings.force_no_reboot) % "Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the USB drive mounted"
     ).min(0).doc_non_optional(true).collapse_synopsys("device-selection");

--- a/main.cpp
+++ b/main.cpp
@@ -611,7 +611,7 @@ auto device_selection =
         (option("--vid") & integer("vid").set(settings.vid).if_missing([] { return "missing vid"; })) % "Filter by vendor id" +
         (option("--pid") & integer("pid").set(settings.pid)) % "Filter by product id" +
         (option("--ser") & value("ser").set(settings.ser)) % "Filter by serial number"
-        + option("--rp2040").set(settings.force_rp2040) % "Use RP2040-specific workarounds when using a custom vid/pid on Windows (ignored on other platforms)"
+        + option("--rp2040").set(settings.force_rp2040) % "Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on other operating systems"
         + option('f', "--force").set(settings.force) % "Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the command (unless the command itself is a 'reboot') the device will be rebooted back to application mode" +
                 option('F', "--force-no-reboot").set(settings.force_no_reboot) % "Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the USB drive mounted"
     ).min(0).doc_non_optional(true).collapse_synopsys("device-selection");
@@ -8707,8 +8707,9 @@ int main(int argc, char **argv) {
                     }
 
                     if (settings.vid == 0 && !settings.ser.empty() && !devices[dr_vidpid_bootrom_ok].empty()) {
-                        // Searching with no vid/pid filtering (ie opening all devices) can cause issues, so stop
-                        // searching when we have a serial number, as we know we have the correct device
+                        // Searching with no vid/pid filtering (ie attempting to open all USB devices to look for a PICOBOOT interface)
+                        // can cause issues, so stop searching when we have found a device with the correct serial number, as we know we have
+                        // the correct device
                         DEBUG_LOG("Found bootrom device with serial number, so stopping search");
                         break;
                     }
@@ -8812,7 +8813,9 @@ int main(int argc, char **argv) {
                                 struct libusb_device_descriptor desc;
                                 libusb_get_device_descriptor(to_reboot, &desc);
                                 if (desc.idProduct == PRODUCT_ID_RP2040_STDIO_USB || settings.force_rp2040) {
-                                    disable_mask = 0;   // enable MSC interface so Zadig works correctly
+                                    // the Zadig driver should be setup for the device in BOOTSEL mode with no interfaces disabled,  
+                                    // as all the interfaces are enabled when you plug it in while holding the BOOTSEL button  
+                                    disable_mask = 0;
                                     settings.force_rp2040 = true;
                                 }
                             }
@@ -8852,7 +8855,7 @@ int main(int argc, char **argv) {
                         settings.address = -1;
                         settings.bus = -1;
                         if (settings.pid != -1 || settings.vid != -1) {
-                            // vid/pid filtering was enabled, but should change in BOOTSEL mode, so needs to be disabled
+                            // vid/pid filtering was enabled, but may change in BOOTSEL mode, so needs to be disabled
                             if (settings.ser.empty()) {
                                 // this is an RP2040 running a no_flash binary, so will have a standard RP2040 vid/pid in BOOTSEL mode
                                 settings.vid = -1; // -1 means filter for standard vid/pid

--- a/main.cpp
+++ b/main.cpp
@@ -8919,7 +8919,7 @@ int main(int argc, char **argv) {
                                 libusb_get_device_descriptor(to_reboot, &desc);
                                 if (desc.idProduct == PRODUCT_ID_RP2040_STDIO_USB || settings.force_rp2040) {
                                     // the Zadig driver should be setup for the device in BOOTSEL mode with no interfaces disabled,  
-                                    // as all the interfaces are enabled when you plug it in while holding the BOOTSEL button  
+                                    // as all the interfaces are enabled when you plug it in while holding down the BOOTSEL button  
                                     disable_mask = 0;
                                     settings.force_rp2040 = true;
                                 }

--- a/picoboot_connection/picoboot_connection.c
+++ b/picoboot_connection/picoboot_connection.c
@@ -184,15 +184,15 @@ enum picoboot_device_result picoboot_open_device(libusb_device *device, libusb_d
                 // Set model based on bootrom vid/pid for RP2040, as it cannot be white-labelled
                 *chip = rp2040;
             } else {
-                // Otherwise check the chip info
+                // Otherwise check the chip info command exists
                 struct picoboot_get_info_cmd info_cmd;
                 info_cmd.bType = PICOBOOT_GET_INFO_SYS,
                 info_cmd.dParams[0] = (uint32_t) (SYS_INFO_CHIP_INFO);
                 uint32_t word_buf[64];
-                // RP2040 doesn't have this function, so returns non-zero
+                // Other devices don't have this function, so will return errors
                 int info_ret = picoboot_get_info(*dev_handle, &info_cmd, (uint8_t*)word_buf, sizeof(word_buf));
                 if (info_ret) {
-                    *chip = rp2040;
+                    return dr_vidpid_unknown;
                 } else {
                     *chip = rp2350;
                 }


### PR DESCRIPTION
Allow forced commands with RP2040 on Windows - they will not deactivate the mass storage device, to ensure Zadig still works

Also fix forced commands with custom vid/pid (as they will change in bootsel mode), by removing vid/pid filters after reboot and just filtering on serial number

Fixes #260 and #261