### PR TITLE
Print the help when --help or -h is unexpectedly encountered.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1719,6 +1719,14 @@ int parse(const int argc, char **argv) {
     };
 
     auto args = cli::make_args(argc, argv);
+
+    // Check if any -h or --help argument was requested, if so insert the help subcommand before any
+    // arguments, this will ensure the correct help gets printed automatically.
+    bool help_requested = std::find(args.begin(), args.end(), "--help") != args.end()
+                          || std::find(args.begin(), args.end(), "-h") != args.end();
+    if (help_requested) {
+      args.insert(args.begin(), "help");
+    }
     if (args.empty()) {
         usage();
         return 0;


### PR DESCRIPTION
Most binaries used on Linux support the '--help' argument, this is a convention specified by the [GNU project][1], as well as in the [clig][2].

Currently, adding `--help` after a failing command gives an error, following by an note at the end on how to get the help. Actually getting the help usually involves pressing the up arrow, removing the erroneous `--help` at the end, moving the cursor to after `picotool` to insert `help` and then succesfully printing out the help.

This commit adds a new error type to the parser to distinguish between parse errors, and errors that can be identified as an attempt to obtain the help. This help error is raised only if an unexpected argument called `--help` is encountered, or an unexpected option `-h`.

In the `main.cpp` this specific error is now caught and handled on appropriately, still relying on the outer catch problematic parse errors, like using command names that don't exist.

[1]: https://www.gnu.org/prep/standards/html_node/Command_002dLine-Interfaces.html
[2]: https://clig.dev/#help

---

Above the line is the commit message, I considered an example too long to be included in it, but before this commit the behaviour is as follows:
```
$ picotool partition info --help

ERROR: unexpected option: --help

SYNOPSIS:
    picotool partition info [-m <family_id>] [device-selection]

Use "picotool help partition info" for more info

```

With this commit, it instead does:
```
$ ./picotool partition info --help
ERROR: unexpected option: --help, this looks like you want the help:
INFO:
    Print the device's partition table.

SYNOPSIS:
    picotool partition info [-m <family_id>] [device-selection]

OPTIONS:
        -m <family_id>
            family ID (will show target partition for said family)
        ... more options.
```

Behaviour when subcommands don't exist is unmodified:
```
$ ./picotool this_doesnt_exist --help

ERROR: Unknown command: this_doesnt_exist

COMMANDS:
    info        Display information from the target device(s) or file.
```
Neither is behaviour when a secondary subcommand is not specified, so in case of `picotool partition --help`, the behaviour is unmodified as that situation already prints the available subcommands. It's really only handling `--help` and `-h` at the end of the commandline, which is muscle memory for many people that live in their terminals.

I at first tried to modify the signature of `match` to use an outparam, but that didn't work as any throws would still end up being handled by the outer throw. I didn't want to return a boolean return to indicate the help is desired, so instead I decided to subclass from the `parse_error` and make a more specific flavour of that.

I've only tested this on Debian GNU/Linux 12, I hope it works with MSVC, I did not find a CONTRIBUTING.md file or `.clang-format` file, so not sure if there's any tests I should/can run.