### PR TITLE
Include pico/usb_reset_interface.h, not pico/stdio_usb/reset_interface.h

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -154,7 +154,6 @@ cc_binary(
         "@pico-sdk//src/common/pico_usb_reset_interface_headers",
         "@pico-sdk//src/rp2350/hardware_regs:otp_data",
         "@pico-sdk//src/rp2_common/pico_bootrom:pico_bootrom_headers",
-        "@pico-sdk//src/rp2_common/pico_stdio_usb:reset_interface_headers",
     ] + select({
         # MSVC can't handle long strings, so use this manually generated
         # header instead.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,8 +303,6 @@ target_compile_definitions(picotool PRIVATE
         )
 # for OTP info
 target_include_directories(picotool PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-# todo, this is a bit of an abstraction failure; but don't want to rev the SDK just for this right now
-target_include_directories(picotool PRIVATE ${PICO_SDK_PATH}/src/rp2_common/pico_stdio_usb/include)
 target_link_libraries(picotool
         pico_binary_info
         boot_uf2_headers

--- a/main.cpp
+++ b/main.cpp
@@ -45,7 +45,7 @@
 #include "elf2uf2.h"
 #include "boot/bootrom_constants.h"
 #include "pico/binary_info.h"
-#include "pico/stdio_usb/reset_interface.h"
+#include "pico/usb_reset_interface.h"
 #include "elf.h"
 #include "otp.h"
 #include "model.h"

--- a/picoboot_connection/BUILD.bazel
+++ b/picoboot_connection/BUILD.bazel
@@ -17,8 +17,8 @@ cc_library(
         "//elf",
         "@libusb",
         "@pico-sdk//src/common/boot_picoboot_headers",
+        "@pico-sdk//src/common/pico_usb_reset_interface_headers",
         "@pico-sdk//src/rp2_common/boot_bootrom_headers",
         "@pico-sdk//src/rp2_common/pico_bootrom:pico_bootrom_headers",
-        "@pico-sdk//src/rp2_common/pico_stdio_usb:reset_interface_headers",
     ],
 )

--- a/picoboot_connection/picoboot_connection.c
+++ b/picoboot_connection/picoboot_connection.c
@@ -11,7 +11,7 @@
 
 #include "picoboot_connection.h"
 #include "boot/bootrom_constants.h"
-#include "pico/stdio_usb/reset_interface.h"
+#include "pico/usb_reset_interface.h"
 
 #if ENABLE_DEBUG_LOG
 #include <stdio.h>


### PR DESCRIPTION
The SDK header was moved in the 2.0.0 release, but picotool still points at the old file - this fixes that