### PR TITLE
Add support for extra security bit

### DIFF
--- a/bintool/metadata.h
+++ b/bintool/metadata.h
@@ -176,6 +176,7 @@ struct image_type_item : public single_byte_size_item {
     image_type_exe_cpu cpu() const { return static_cast<image_type_exe_cpu>((flags & PICOBIN_IMAGE_TYPE_EXE_CPU_BITS) >> PICOBIN_IMAGE_TYPE_EXE_CPU_LSB); }
     image_type_exe_chip chip() const { return static_cast<image_type_exe_chip>((flags & PICOBIN_IMAGE_TYPE_EXE_CHIP_BITS) >> PICOBIN_IMAGE_TYPE_EXE_CHIP_LSB); }
     bool tbyb() const { return flags & PICOBIN_IMAGE_TYPE_EXE_TBYB_BITS; }
+    bool extra_security() const { return flags & PICOBIN_IMAGE_TYPE_EXE_EXTRA_SECURITY_BITS; }
 
     uint16_t flags;
 };

--- a/bintool/metadata.h
+++ b/bintool/metadata.h
@@ -16,6 +16,12 @@
 #define DEBUG_LOG(...) ((void)0)
 #endif
 
+// Support for SDK 2.1.0 & SDK 2.1.1 -----
+#ifndef PICOBIN_IMAGE_TYPE_EXE_EXTRA_SECURITY_BITS
+#define PICOBIN_IMAGE_TYPE_EXE_EXTRA_SECURITY_BITS _u(0x0800)
+#endif
+// ------
+
 struct item;
 
 template<typename InputIterator> std::vector<uint32_t> lsb_bytes_to_words(InputIterator begin, InputIterator end) {

--- a/main.cpp
+++ b/main.cpp
@@ -3362,8 +3362,8 @@ void info_guts(memory_access &raw_access, void *con) {
                     info_pair("tbyb", "not bought");
                 }
 
-                if (image_def->extra_security() && verbose_metadata) {
-                    info_pair("extra security", "enabled");
+                if (verbose_metadata) {
+                    info_pair("extra security", image_def->extra_security() ? "enabled" : "not enabled");
                 }
             }
 

--- a/main.cpp
+++ b/main.cpp
@@ -3361,6 +3361,10 @@ void info_guts(memory_access &raw_access, void *con) {
                 if (image_def->tbyb()) {
                     info_pair("tbyb", "not bought");
                 }
+
+                if (image_def->extra_security()) {
+                    info_pair("extra security", "enabled");
+                }
             }
 
             // Partition Table
@@ -5078,9 +5082,11 @@ void sign_guts_elf(elf_file* elf, private_t private_key, public_t public_key) {
         new_block.items.push_back(version);
     }
 
-    // Add entry point when signing Arm images
+    // Add entry point and vector table when signing Arm images, and set PICOBIN_IMAGE_TYPE_EXE_EXTRA_SECURITY_BITS
     std::shared_ptr<image_type_item> image_type = new_block.get_item<image_type_item>();
     if (settings.seal.sign && image_type != nullptr && image_type->image_type() == type_exe && image_type->cpu() == cpu_arm) {
+        // Set PICOBIN_IMAGE_TYPE_EXE_EXTRA_SECURITY_BITS
+        image_type->flags |= PICOBIN_IMAGE_TYPE_EXE_EXTRA_SECURITY_BITS;
         std::shared_ptr<entry_point_item> entry_point = new_block.get_item<entry_point_item>();
         if (entry_point == nullptr) {
             std::shared_ptr<vector_table_item> vtor = new_block.get_item<vector_table_item>();
@@ -5099,6 +5105,9 @@ void sign_guts_elf(elf_file* elf, private_t private_key, public_t public_key) {
                         vtor_loc += rwd->addr;
                     }
                 }
+
+                vtor = std::make_shared<vector_table_item>(vtor_loc);
+                new_block.items.push_back(vtor);
             }
             auto segment = elf->segment_from_virtual_address(vtor_loc);
             if (segment == nullptr) {
@@ -5159,15 +5168,20 @@ vector<uint8_t> sign_guts_bin(iostream_memory_access in, private_t private_key, 
         new_block.items.push_back(version);
     }
 
-    // Add entry point when signing Arm images
+    // Add entry point and vector table when signing Arm images, and set PICOBIN_IMAGE_TYPE_EXE_EXTRA_SECURITY_BITS
     std::shared_ptr<image_type_item> image_type = new_block.get_item<image_type_item>();
     if (settings.seal.sign && image_type != nullptr && image_type->image_type() == type_exe && image_type->cpu() == cpu_arm) {
+        // Set PICOBIN_IMAGE_TYPE_EXE_EXTRA_SECURITY_BITS
+        image_type->flags |= PICOBIN_IMAGE_TYPE_EXE_EXTRA_SECURITY_BITS;
         std::shared_ptr<entry_point_item> entry_point = new_block.get_item<entry_point_item>();
         if (entry_point == nullptr) {
             std::shared_ptr<vector_table_item> vtor = new_block.get_item<vector_table_item>();
             uint32_t vtor_loc = bin_start;
             if (vtor != nullptr) {
                 vtor_loc = vtor->addr;
+            } else {
+                vtor = std::make_shared<vector_table_item>(vtor_loc);
+                new_block.items.push_back(vtor);
             }
             auto offset = vtor_loc - bin_start;
             uint32_t ep;

--- a/main.cpp
+++ b/main.cpp
@@ -3362,7 +3362,7 @@ void info_guts(memory_access &raw_access, void *con) {
                     info_pair("tbyb", "not bought");
                 }
 
-                if (image_def->extra_security()) {
+                if (image_def->extra_security() && verbose_metadata) {
                     info_pair("extra security", "enabled");
                 }
             }


### PR DESCRIPTION
Set this by default when signing Arm images, in addition to adding a vector table and entry point if they're not present

This bit has no effect on chip revisions <A4, on A4 it requires that the image has both a vector table and an entry point