### PR TITLE
Update udev rule

### DIFF
--- a/udev/60-picotool.rules
+++ b/udev/60-picotool.rules
@@ -1,27 +1,42 @@
 # Copy this file to /etc/udev/rules.d/
 # You can reload the udev rules with "udevadm control --reload"
 
+# Rules for plugdev access
 SUBSYSTEM=="usb", \
     ATTRS{idVendor}=="2e8a", \
     ATTRS{idProduct}=="0003", \
-    TAG+="uaccess", \
     MODE="660", \
     GROUP="plugdev"
 SUBSYSTEM=="usb", \
     ATTRS{idVendor}=="2e8a", \
     ATTRS{idProduct}=="0009", \
-    TAG+="uaccess", \
     MODE="660", \
     GROUP="plugdev"
 SUBSYSTEM=="usb", \
     ATTRS{idVendor}=="2e8a", \
     ATTRS{idProduct}=="000a", \
-    TAG+="uaccess", \
     MODE="660", \
     GROUP="plugdev"
 SUBSYSTEM=="usb", \
     ATTRS{idVendor}=="2e8a", \
     ATTRS{idProduct}=="000f", \
-    TAG+="uaccess", \
     MODE="660", \
     GROUP="plugdev"
+
+# Rules for seat access
+SUBSYSTEM=="usb", \
+    ATTRS{idVendor}=="2e8a", \
+    ATTRS{idProduct}=="0003", \
+    TAG+="uaccess"
+SUBSYSTEM=="usb", \
+    ATTRS{idVendor}=="2e8a", \
+    ATTRS{idProduct}=="0009", \
+    TAG+="uaccess"
+SUBSYSTEM=="usb", \
+    ATTRS{idVendor}=="2e8a", \
+    ATTRS{idProduct}=="000a", \
+    TAG+="uaccess"
+SUBSYSTEM=="usb", \
+    ATTRS{idVendor}=="2e8a", \
+    ATTRS{idProduct}=="000f", \
+    TAG+="uaccess"


### PR DESCRIPTION
Any rule with the GROUP= setting with a non-system group gets ignored since systemd 258, uaccess handle handles access so its redundant.

For uaccess the udev developers recommend applying it on add and change actions but not on remove, adapted the rule to follow this.

Tested on Fedora 43