### PR TITLE
Fix MSVC build problems caused by 'windows.h'

### DIFF
--- a/elf/elf_file.cpp
+++ b/elf/elf_file.cpp
@@ -23,11 +23,7 @@
 
 #include "portable_endian.h"
 
-// tsk namespace is polluted on windows
 #ifdef _WIN32
-#undef min
-#undef max
-
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 

--- a/elf/portable_endian.h
+++ b/elf/portable_endian.h
@@ -61,7 +61,7 @@
 #endif
 
 #elif defined(__WINDOWS__)
-
+#	define NOMINMAX
 #	include <winsock2.h>
 #	ifdef __GNUC__
 #		include <sys/param.h>

--- a/main.cpp
+++ b/main.cpp
@@ -69,13 +69,6 @@ static __forceinline int __builtin_ctz(unsigned x) {
 }
 #endif
 
-// tsk namespace is polluted on windows
-#ifdef _WIN32
-#undef min
-#undef max
-
-#define _CRT_SECURE_NO_WARNINGS
-#endif
 
 #define MAX_REBOOT_TRIES 5
 
@@ -8601,13 +8594,6 @@ bool reboot_command::execute(device_map &devices) {
 #include <sys/ioctl.h>
 #endif
 
-// tsk namespace is polluted on windows
-#ifdef _WIN32
-#undef min
-#undef max
-
-#define _CRT_SECURE_NO_WARNINGS
-#endif
 
 static void sleep_ms(int ms) {
 #if defined(__unix__) || defined(__APPLE__)

--- a/main.cpp
+++ b/main.cpp
@@ -72,13 +72,6 @@ static __forceinline int __builtin_ctz(unsigned x) {
 }
 #endif
 
-// tsk namespace is polluted on windows
-#ifdef _WIN32
-#undef min
-#undef max
-
-#define _CRT_SECURE_NO_WARNINGS
-#endif
 
 // preprocessor macros
 #define STR_HELPER(x) #x
@@ -10149,13 +10142,6 @@ bool reboot_command::execute(device_map &devices) {
 #include <sys/ioctl.h>
 #endif
 
-// tsk namespace is polluted on windows
-#ifdef _WIN32
-#undef min
-#undef max
-
-#define _CRT_SECURE_NO_WARNINGS
-#endif
 
 static void sleep_ms(int ms) {
 #if defined(__unix__) || defined(__APPLE__)

--- a/model/model.h
+++ b/model/model.h
@@ -21,11 +21,7 @@
 #include "rp2350_a3_rom_end.h"
 #include "rp2350_a4_rom_end.h"
 
-// tsk namespace is polluted on windows
 #ifdef _WIN32
-#undef min
-#undef max
-
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 

--- a/picoboot_connection/picoboot_connection.h
+++ b/picoboot_connection/picoboot_connection.h
@@ -11,6 +11,9 @@
 
 #include <assert.h>
 #if HAS_LIBUSB
+#ifdef _WIN32
+#define NOMINMAX
+#endif
 #include <libusb.h>
 #endif
 #include "boot/picoboot.h"

--- a/picoboot_connection/picoboot_connection_cxx.cpp
+++ b/picoboot_connection/picoboot_connection_cxx.cpp
@@ -11,9 +11,6 @@
 #include "picoboot_connection_cxx.h"
 
 #ifdef _WIN32
-#undef min
-#undef max
-
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 


### PR DESCRIPTION
Fix the problem when building with MSVC due to a macro conflict, arising from including `windows.h` without a preceding `#define NOMINMAX` (as it re-defines `min`/`max` otherwise).  
In this case, [`picoboot_connection.h`](https://github.com/raspberrypi/picotool/blob/master/picoboot_connection/picoboot_connection.h) included the `libusb.h` header unguardedly, which in turn includes `windows.h`.  This was previously fixed with `#undef min/max`, but in [`main.cpp`](https://github.com/raspberrypi/picotool/blob/master/main.cpp) only *after* including [`model.h`](https://github.com/raspberrypi/picotool/blob/master/model/model.h), where the error occurred.
Also added the guard to [`portable_endian.h`](https://github.com/raspberrypi/picotool/blob/master/elf/portable_endian.h), the other place where `windows.h` might be included (through `winsock2.h`), and cleaned up the now obsolete `#undef`s.


Fixes #288.