### PR TITLE
Fix MSVC build and CI tests

### DIFF
--- a/.github/workflows/choco_packages_mingw.config
+++ b/.github/workflows/choco_packages_mingw.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="gcc-arm-embedded" version="10.2.1" />
   <package id="mingw" version="12.2.0" />
-  <package id="ninja" version="1.11.1" />
 </packages>

--- a/.github/workflows/choco_packages_mingw.config
+++ b/.github/workflows/choco_packages_mingw.config
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="gcc-arm-embedded" version="10.2.1" />
-  <package id="mingw" version="12.2.0" />
-</packages>

--- a/.github/workflows/choco_packages_msvc.config
+++ b/.github/workflows/choco_packages_msvc.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="gcc-arm-embedded" version="10.2.1" />
-</packages>

--- a/.github/workflows/choco_packages_msvc.config
+++ b/.github/workflows/choco_packages_msvc.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="gcc-arm-embedded" version="10.2.1" />
+</packages>

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,8 +86,11 @@ jobs:
         run: |
           picotool help
           curl -L https://datasheets.raspberrypi.com/soft/blink.uf2 -o blink.uf2
+          unzip -o blink.uf2 || true
           curl -L https://datasheets.raspberrypi.com/soft/hello_world.uf2 -o hello_world.uf2
+          unzip -o hello_world.uf2 || true
           curl -L https://datasheets.raspberrypi.com/soft/flash_nuke.uf2 -o flash_nuke.uf2
+          unzip -o flash_nuke.uf2 || true
           picotool info -a blink.uf2
           picotool info -a hello_world.uf2
           picotool info -a flash_nuke.uf2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,6 @@ jobs:
             generator: "Visual Studio 17 2022"
           - libusb: ""
             compile: "compile"
-          - os: 'windows-latest'
-            # currently skipping compile for Windows, as gcc-arm-embedded package has broken links
-            compile: "compile"
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -36,10 +33,14 @@ jobs:
         if: runner.os == 'Windows' && matrix.generator == 'Ninja'
         run: |
           choco install -y mingw --version=12.2.0
+      - name: Install arm-none-eabi-gcc (Windows & MacOS)
+        if: runner.os == 'Windows' || runner.os == 'macOS'
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
+        with:
+          release: 14.3.Rel1
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          choco install -y gcc-arm-embedded
           curl -L https://github.com/libusb/libusb/releases/download/v1.0.27/libusb-1.0.27.7z -o libusb.7z
           7z x libusb.7z -olibusb
           ls libusb
@@ -56,7 +57,6 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install libusb ninja
-          brew install --cask gcc-arm-embedded
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           cmake -S . -B build -G "${{ matrix.generator }}" -D PICO_SDK_PATH="${{ github.workspace }}/pico-sdk" ${{ !matrix.libusb && '-D PICOTOOL_NO_LIBUSB=1' || '' }} ${{ matrix.compile && '-D USE_PRECOMPILED=false' || '' }}
           cmake --build build
-          ${{ runner.os != 'Windows' && 'sudo' || '' }} cmake --install build
+          ${{ runner.os != 'Windows' && 'sudo' || '' }} cmake --install build --config Debug
       - name: Add to path (Windows)
         if: runner.os == 'Windows'
         run: echo "C:\Program Files (x86)\picotool\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,17 +29,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install compilers (Windows mingw)
+      - name: Install mingw (Windows mingw)
         if: runner.os == 'Windows' && matrix.generator == 'Ninja'
         run: |
-          choco install -y .github/workflows/choco_packages_mingw.config
-      - name: Install compilers (Windows msvc)
-        if: runner.os == 'Windows' && matrix.generator == 'Visual Studio 17 2022'
-        run: |
-          choco install -y .github/workflows/choco_packages_msvc.config
+          choco install -y mingw --version=12.2.0
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
+          choco install -y gcc-arm-embedded
           curl -L https://github.com/libusb/libusb/releases/download/v1.0.27/libusb-1.0.27.7z -o libusb.7z
           7z x libusb.7z -olibusb
           ls libusb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,10 @@ jobs:
             generator: "Visual Studio 17 2022"
           - libusb: ""
             compile: "compile"
+          - os: 'windows-latest'
+            # only precompiled ELFs supported for Windows MSVC
+            compile: "compile"
+            generator: "Visual Studio 17 2022"
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
             generator: "Visual Studio 17 2022"
           - libusb: ""
             compile: "compile"
+          - os: 'windows-latest'
+            # currently skipping compile for Windows, as gcc-arm-embedded package has broken links
+            compile: "compile"
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        generator: ["Ninja", "Unix Makefiles"]
+        generator: ["Ninja", "Unix Makefiles", "Visual Studio 17 2022"]
         mbedtls: ["mbedtls", ""]
         libusb: ["libusb", ""]
         compile: ["compile", ""]
         exclude:
           - os: 'windows-latest'
             generator: "Unix Makefiles"
+          - os: 'ubuntu-latest'
+            generator: "Visual Studio 17 2022"
+          - os: 'macos-latest'
+            generator: "Visual Studio 17 2022"
           - libusb: ""
             compile: "compile"
     runs-on: ${{ matrix.os }}
@@ -25,10 +29,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install compilers (Windows mingw)
+        if: runner.os == 'Windows' && matrix.generator == 'Ninja'
+        run: |
+          choco install -y .github/workflows/choco_packages_mingw.config
+      - name: Install compilers (Windows msvc)
+        if: runner.os == 'Windows' && matrix.generator == 'Visual Studio 17 2022'
+        run: |
+          choco install -y .github/workflows/choco_packages_msvc.config
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          choco install -y .github/workflows/choco_packages.config
           curl -L https://github.com/libusb/libusb/releases/download/v1.0.27/libusb-1.0.27.7z -o libusb.7z
           7z x libusb.7z -olibusb
           ls libusb

--- a/model/model.h
+++ b/model/model.h
@@ -12,6 +12,14 @@
 #include "rp2350_a3_rom_end.h"
 #include "rp2350_a4_rom_end.h"
 
+// tsk namespace is polluted on windows
+#ifdef _WIN32
+#undef min
+#undef max
+
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 enum memory_type {
     rom,
     flash,


### PR DESCRIPTION
Fix MSVC build, and add CI test of the MSVC build

Also fix the CI tests, as the UF2 files may now be ZIP files, so may need unzipping before use