### PR TITLE
Issue exit_xip before erasing

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4752,6 +4752,7 @@ bool erase_command::execute(device_map &devices) {
 
     {
         progress_bar bar("Erasing: ");
+        con.exit_xip();
         for (uint32_t addr = start; addr < end; addr += FLASH_SECTOR_ERASE_SIZE) {
             bar.progress(addr-start, end-start);
             con.flash_erase(addr, FLASH_SECTOR_ERASE_SIZE);


### PR DESCRIPTION
This is required on RP2040 when erasing using `--range` (normal erase will have already issued one when it reads to guess the flash size) - the other flash commands (eg load) already add it for all chips so do the same here, rather than filtering as RP2040 only