### PR TITLE
Check value of partition flags for ignoring boot

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1931,6 +1931,15 @@ bool get_json_int(json value, T& out) {
     }
 }
 
+bool get_json_boolean(json value, bool& out) {
+    if (value.is_boolean()) {
+        out = value.get<bool>();
+        return true;
+    } else {
+        return false;
+    }
+}
+
 uint32_t bootrom_func_lookup_rp2040(memory_access& access, uint16_t tag) {
     model_t model = access.get_model();
     // we are only used on RP2040
@@ -6564,8 +6573,21 @@ bool partition_create_command::execute(device_map &devices) {
 
         if(p.contains("no_reboot_on_uf2_download")) new_p.flags |= PICOBIN_PARTITION_FLAGS_UF2_DOWNLOAD_NO_REBOOT_BITS;
         if(p.contains("ab_non_bootable_owner_affinity")) new_p.flags |= PICOBIN_PARTITION_FLAGS_UF2_DOWNLOAD_AB_NON_BOOTABLE_OWNER_AFFINITY;
-        if(p.contains("ignored_during_riscv_boot")) new_p.flags |= PICOBIN_PARTITION_FLAGS_IGNORED_DURING_RISCV_BOOT_BITS;
-        if(p.contains("ignored_during_arm_boot")) new_p.flags |= PICOBIN_PARTITION_FLAGS_IGNORED_DURING_ARM_BOOT_BITS;
+
+        if(p.contains("ignored_during_riscv_boot")) {
+            bool ignored_value;
+            if (get_json_boolean(p["ignored_during_riscv_boot"], ignored_value) && ignored_value) {
+                new_p.flags |= PICOBIN_PARTITION_FLAGS_IGNORED_DURING_RISCV_BOOT_BITS;
+            }
+        }
+
+        if(p.contains("ignored_during_arm_boot")) {
+            bool ignored_value;
+            if (get_json_boolean(p["ignored_during_arm_boot"], ignored_value) && ignored_value) {
+                new_p.flags |= PICOBIN_PARTITION_FLAGS_IGNORED_DURING_ARM_BOOT_BITS;
+            }
+        }
+
         pt.partitions.push_back(new_p);
     }
 


### PR DESCRIPTION
Spent a bit of time wondering why my partition boot flags were different to what I had specified!

In the JSON input file, we're currently simply checking if the flags `ignored_during_riscv_boot` and `ignored_during_arm_boot` are present. If so, they're ignored.

So this:

`"ignored_during_riscv_boot": true`

is currently evaluated exactly the same as this:

`"ignored_during_riscv_boot": false`

This PR adds a get_json_boolean function based on the get_json_int functions to parse the value part of the JSON key/value entry, and we now take the boolean value into account rather than just the if the key is present or not. 