### PR TITLE
Improve documentation in 60-picotool.rules

### DIFF
--- a/udev/60-picotool.rules
+++ b/udev/60-picotool.rules
@@ -1,5 +1,9 @@
 # Copy this file to /etc/udev/rules.d/
 # You can reload the udev rules with "udevadm control --reload"
+# You may need to remove the GROUP= lines when not using Raspberry Pi OS, leaving the rules as:
+# SUBSYSTEM=="usb", \
+#     ...
+#     MODE="660"
 
 SUBSYSTEM=="usb", \
     ATTRS{idVendor}=="2e8a", \


### PR DESCRIPTION
Add note about removing groups for non Raspberry Pi OS systems

This is an alternative to https://github.com/raspberrypi/picotool/pull/285, as the `GROUP=plugdev` is still required on Raspberry Pi OS in some scenarios