### PR TITLE
Don't fail CI when curl is unable to check CRL for the sample UF2 files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,11 +85,11 @@ jobs:
       - name: Test
         run: |
           picotool help
-          curl -L https://datasheets.raspberrypi.com/soft/blink.uf2 -o blink.uf2
+          curl -L --ssl-revoke-best-effort https://datasheets.raspberrypi.com/soft/blink.uf2 -o blink.uf2
           unzip -o blink.uf2 || true
-          curl -L https://datasheets.raspberrypi.com/soft/hello_world.uf2 -o hello_world.uf2
+          curl -L --ssl-revoke-best-effort https://datasheets.raspberrypi.com/soft/hello_world.uf2 -o hello_world.uf2
           unzip -o hello_world.uf2 || true
-          curl -L https://datasheets.raspberrypi.com/soft/flash_nuke.uf2 -o flash_nuke.uf2
+          curl -L --ssl-revoke-best-effort https://datasheets.raspberrypi.com/soft/flash_nuke.uf2 -o flash_nuke.uf2
           unzip -o flash_nuke.uf2 || true
           picotool info -a blink.uf2
           picotool info -a hello_world.uf2


### PR DESCRIPTION
The reason for this failure is unclear, but it's definitely not a fatal error