### PR TITLE
Add support for bootsel activity LED

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -106,8 +106,8 @@ The `picotool` build has some CMake variables you can use to customise how the b
 - `GENERATE_FIXED_DOCS_WIDTH`: By default the width of the output from `picotool` adjusts to the width of the terminal. Setting this to `true` fixes the width to 140, which is used when generating the [README](README.md).
 - `DEFAULT_BOOTSEL_LED`: This can be used to set the default value for the `--led` argument, so `picotool` always reboots devices to BOOTSEL with that LED flashing.
 - `PICOTOOL_NO_LIBUSB`: By default `picotool` is compiled with USB support if libusb is found. Setting this to `true` explicitly compiles without USB support, which is used when the Pico SDK builds picotool.
-- `USE_PRECOMPILED`: By default the build uses pre-compiles ELF/BIN files for code that is run on the device (enc_bootloader, xip_ram_perms, and picoboot_flash_id). Setting this to `false` re-compiles these files instead.
+- `USE_PRECOMPILED`: By default the build uses pre-compiled ELF/BIN files for code that is run on the device (enc_bootloader, xip_ram_perms, and picoboot_flash_id). Setting this to `false` re-compiles these files instead.
 
-These can all be set by passing `-DNAME=VALUE` to your `cmake` command (e.g. `-DGENERATE_FIXED_DOCS_WIDTH=1`).
+These can all be set by passing `-DNAME=VALUE` to your `cmake` command (e.g. `-DGENERATE_FIXED_DOCS_WIDTH=true`).
 
-Note that the behaviour when setting `PICOTOOL_NO_LIBUSB` or `USE_PRECOMPILED` is undefined when using an existing build directory, due to the use of CMake external projects - instead you should create a new build directory to ensure it is in the correct state.
+Note: when setting `PICOTOOL_NO_LIBUSB` or `USE_PRECOMPILED` you should create a new build directory (rather than using an existing build directory), due to the way `picotool` uses external CMake projects.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -97,3 +97,17 @@ make install
 In order for the SDK to find `picotool` in this custom folder, you will usually need to set the `picotool_DIR` variable in your project. This can be achieved either by setting the `picotool_DIR` environment variable to `$MY_INSTALL_DIR/picotool`, by passing `-Dpicotool_DIR=$MY_INSTALL_DIR/picotool` to your `cmake` command, or by adding `set(picotool_DIR $MY_INSTALL_DIR/picotool)` to your CMakeLists.txt file.
 
 > See the [find_package documentation](https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure) for more details
+
+
+## Customising the build
+
+The `picotool` build has some CMake variables you can use to customise how the build works, and how `picotool` functions:
+
+- `GENERATE_FIXED_DOCS_WIDTH`: By default the width of the output from `picotool` adjusts to the width of the terminal. Setting this to `true` fixes the width to 140, which is used when generating the [README](README.md).
+- `DEFAULT_BOOTSEL_LED`: This can be used to set the default value for the `--led` argument, so `picotool` always reboots devices to BOOTSEL with that LED flashing.
+- `PICOTOOL_NO_LIBUSB`: By default `picotool` is compiled with USB support if libusb is found. Setting this to `true` explicitly compiles without USB support, which is used when the Pico SDK builds picotool.
+- `USE_PRECOMPILED`: By default the build uses pre-compiles ELF/BIN files for code that is run on the device (enc_bootloader, xip_ram_perms, and picoboot_flash_id). Setting this to `false` re-compiles these files instead.
+
+These can all be set by passing `-DNAME=VALUE` to your `cmake` command (e.g. `-DGENERATE_FIXED_DOCS_WIDTH=1`).
+
+Note that the behaviour when setting `PICOTOOL_NO_LIBUSB` or `USE_PRECOMPILED` is undefined when using an existing build directory, due to the use of CMake external projects - instead you should create a new build directory to ensure it is in the correct state.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -104,7 +104,7 @@ In order for the SDK to find `picotool` in this custom folder, you will usually 
 The `picotool` build has some CMake variables you can use to customise how the build works, and how `picotool` functions:
 
 - `GENERATE_FIXED_DOCS_WIDTH`: By default the width of the output from `picotool` adjusts to the width of the terminal. Setting this to `true` fixes the width to 140, which is used when generating the [README](README.md).
-- `DEFAULT_BOOTSEL_LED`: This can be used to set the default value for the `--led` argument, so `picotool` always reboots devices to BOOTSEL with that LED flashing.
+- `DEFAULT_BOOTSEL_LED`: This can be used to set the default value for the `--bootsel-led` argument, so `picotool` always reboots devices to BOOTSEL with that LED flashing.
 - `PICOTOOL_NO_LIBUSB`: By default `picotool` is compiled with USB support if libusb is found. Setting this to `true` explicitly compiles without USB support, which is used when the Pico SDK builds picotool.
 - `USE_PRECOMPILED`: By default the build uses pre-compiled ELF/BIN files for code that is run on the device (enc_bootloader, xip_ram_perms, and picoboot_flash_id). Setting this to `false` re-compiles these files instead.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -104,10 +104,10 @@ In order for the SDK to find `picotool` in this custom folder, you will usually 
 The `picotool` build has some CMake variables you can use to customise how the build works, and how `picotool` functions:
 
 - `GENERATE_FIXED_DOCS_WIDTH`: By default the width of the output from `picotool` adjusts to the width of the terminal. Setting this to `true` fixes the width to 140, which is used when generating the [README](README.md).
-- `DEFAULT_BOOTSEL_LED`: This can be used to set the default value for the `--bootsel-led` argument, so `picotool` always reboots devices to BOOTSEL with that LED flashing.
+- `DEFAULT_BOOTSEL_LED`: This can be used to set the default value for the `--bootsel-led` argument, so `picotool` always reboots devices to BOOTSEL with that LED used as the activity indicator.
 - `PICOTOOL_NO_LIBUSB`: By default `picotool` is compiled with USB support if libusb is found. Setting this to `true` explicitly compiles without USB support, which is used when the Pico SDK builds picotool.
 - `USE_PRECOMPILED`: By default the build uses pre-compiled ELF/BIN files for code that is run on the device (enc_bootloader, xip_ram_perms, and picoboot_flash_id). Setting this to `false` re-compiles these files instead.
 
 These can all be set by passing `-DNAME=VALUE` to your `cmake` command (e.g. `-DGENERATE_FIXED_DOCS_WIDTH=true`).
 
-Note: when setting `PICOTOOL_NO_LIBUSB` or `USE_PRECOMPILED` you should create a new build directory (rather than using an existing build directory), due to the way `picotool` uses external CMake projects.
+Note: when setting `PICOTOOL_NO_LIBUSB` or `USE_PRECOMPILED` you should create a new build directory (rather than using an existing build directory), due to the way `picotool` uses external CMake projects.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,10 @@ else()
         ${LIBUSB_LIBRARIES})
 endif()
 
+if (DEFAULT_BOOTSEL_LED)
+    target_compile_definitions(picotool PRIVATE DEFAULT_BOOTSEL_LED=${DEFAULT_BOOTSEL_LED})
+endif()
+
 if (GENERATE_FIXED_DOCS_WIDTH)
     target_compile_definitions(picotool PRIVATE DOCS_WIDTH=140)
 endif()

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ TARGET SELECTION:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
     To target a file
         <filename>
             The file name
@@ -237,11 +237,11 @@ TARGET SELECTION:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
     To target a file
         <filename>
             The file name
@@ -347,11 +347,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
 ```
 
 e.g.
@@ -421,11 +421,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
 ```
 
 e.g. first looking at what is on the device...
@@ -503,11 +503,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
 ```
 
 ## erase
@@ -560,11 +560,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
 ```
 
 e.g. first looking at what is on the device...
@@ -650,11 +650,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
 ```
 
 ## seal
@@ -837,11 +837,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
 ```
 
 ```text
@@ -1002,11 +1002,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
 ```
 
 ## otp
@@ -1109,11 +1109,11 @@ TARGET SELECTION:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
 ```
 
 ```text
@@ -1177,11 +1177,11 @@ TARGET SELECTION:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
 ```
 
 ### load
@@ -1232,11 +1232,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
 ```
 
 For example, if you wish to sign a binary and then test secure boot with it, you can run the following set of commands:
@@ -1284,11 +1284,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
 ```
 
 ```text
@@ -1377,11 +1377,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
 ```
 
 ```text
@@ -1450,11 +1450,11 @@ TARGET SELECTION:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
-        --led <led>
-            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
-            to BOOTSEL mode
-        --active-low
-            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
+        --bootsel-led <gpio>
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            this command reboots the device to BOOTSEL mode
+        --bootsel-led-active-low
+            The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
     To dump the contents of an OTP JSON file
         <input>
             The file name

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ TARGET SELECTION:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -238,7 +238,7 @@ TARGET SELECTION:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -348,7 +348,7 @@ OPTIONS:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -422,7 +422,7 @@ OPTIONS:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -504,7 +504,7 @@ OPTIONS:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -561,7 +561,7 @@ OPTIONS:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -651,7 +651,7 @@ OPTIONS:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -838,7 +838,7 @@ OPTIONS:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -1003,7 +1003,7 @@ OPTIONS:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -1110,7 +1110,7 @@ TARGET SELECTION:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -1178,7 +1178,7 @@ TARGET SELECTION:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -1233,7 +1233,7 @@ OPTIONS:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -1285,7 +1285,7 @@ OPTIONS:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -1378,7 +1378,7 @@ OPTIONS:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)
@@ -1451,7 +1451,7 @@ TARGET SELECTION:
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
         --bootsel-led <gpio>
-            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350-A2 in Arm mode) - only applicable if
+            Specify the GPIO for the BOOTSEL activity LED to flash (default none, ignored by RP2350A-A2 in Arm mode) - only applicable if
             this command reboots the device to BOOTSEL mode
         --bootsel-led-active-low
             The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)

--- a/README.md
+++ b/README.md
@@ -123,14 +123,17 @@ TARGET SELECTION:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
     To target a file
         <filename>
             The file name
         -t <type>
             Specify file type (uf2 | elf | bin) explicitly, ignoring file extension
 ```
-
-Note the -f arguments vary slightly for Windows vs macOS / Unix platforms.
 
 e.g.
 
@@ -234,6 +237,11 @@ TARGET SELECTION:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
     To target a file
         <filename>
             The file name
@@ -339,6 +347,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
 ```
 
 e.g.
@@ -408,6 +421,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
 ```
 
 e.g. first looking at what is on the device...
@@ -485,6 +503,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
 ```
 
 ## erase
@@ -537,6 +560,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
 ```
 
 e.g. first looking at what is on the device...
@@ -622,6 +650,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
 ```
 
 ## seal
@@ -804,6 +837,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
 ```
 
 ```text
@@ -964,6 +1002,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
 ```
 
 ## otp
@@ -1066,6 +1109,11 @@ TARGET SELECTION:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
 ```
 
 ```text
@@ -1129,6 +1177,11 @@ TARGET SELECTION:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
 ```
 
 ### load
@@ -1179,6 +1232,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
 ```
 
 For example, if you wish to sign a binary and then test secure boot with it, you can run the following set of commands:
@@ -1226,6 +1284,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
 ```
 
 ```text
@@ -1314,6 +1377,11 @@ OPTIONS:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
 ```
 
 ```text
@@ -1382,6 +1450,11 @@ TARGET SELECTION:
             Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the
             command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the
             USB drive mounted
+        --led <led>
+            Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device
+            to BOOTSEL mode
+        --active-low
+            The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)
     To dump the contents of an OTP JSON file
         <input>
             The file name

--- a/main.cpp
+++ b/main.cpp
@@ -651,7 +651,7 @@ auto device_selection =
     #else
         STR(DEFAULT_BOOTSEL_LED)
     #endif
-        ", ignored by RP2350-A2 in Arm mode) - only applicable if this command reboots the device to BOOTSEL mode"
+        ", ignored by RP2350A-A2 in Arm mode) - only applicable if this command reboots the device to BOOTSEL mode"
         + option("--bootsel-led-active-low").set(settings.active_low) % "The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)"
     ).min(0).doc_non_optional(true).collapse_synopsys("device-selection");
 

--- a/main.cpp
+++ b/main.cpp
@@ -489,6 +489,10 @@ private:
      std::vector<std::shared_ptr<cmd>> _sub_commands;
 };
 
+#ifndef DEFAULT_BOOTSEL_LED
+#define DEFAULT_BOOTSEL_LED -1
+#endif
+
 struct _settings {
     std::array<std::string, 6> filenames;
     std::array<std::string, 6> file_types;
@@ -498,6 +502,8 @@ struct _settings {
     int vid=-1;
     int pid=-1;
     string ser;
+    int led=DEFAULT_BOOTSEL_LED;
+    bool active_low=false;
     bool force_rp2040 = false;
     uint32_t offset = 0;
     uint32_t from = 0;
@@ -633,6 +639,8 @@ auto device_selection =
         + option("--rp2040").set(settings.force_rp2040) % "Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on other operating systems"
         + option('f', "--force").set(settings.force) % "Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the command (unless the command itself is a 'reboot') the device will be rebooted back to application mode" +
                 option('F', "--force-no-reboot").set(settings.force_no_reboot) % "Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the USB drive mounted"
+        + (option("--led") & integer("led").set(settings.led)) % "Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device to BOOTSEL mode"
+        + option("--active-low").set(settings.active_low) % "The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)"
     ).min(0).doc_non_optional(true).collapse_synopsys("device-selection");
 
 #define file_types_x(i)\
@@ -8610,6 +8618,9 @@ static int reboot_device(libusb_device *device, libusb_device_handle *dev_handle
                 fail(ERROR_USB, "Failed to claim interface\n");
             }
             if (bootsel) {
+                if (settings.led >= 0) {
+                    disable_mask |= (settings.led << 9u) | (settings.active_low << 7u) | (1u << 8u);
+                }
                 ret = libusb_control_transfer(dev_handle, LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE,
                                               RESET_REQUEST_BOOTSEL, disable_mask, i, nullptr, 0, 2000);
             } else {
@@ -8648,11 +8659,12 @@ bool reboot_command::execute(device_map &devices) {
         picoboot_memory_access raw_access(con);
         model_t model = raw_access.get_model();
         if (model->supports_picoboot_cmd(PC_REBOOT2)) {
+            uint32_t usb_flags = (settings.led >= 0) ? (settings.active_low ? 0x30u : 0x20u) : 0u;
             struct picoboot_reboot2_cmd cmd = {
                     .dFlags = (uint8_t)(settings.reboot_usb ? REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL : REBOOT2_FLAG_REBOOT_TYPE_NORMAL),
                     .dDelayMS = 500,
-                    .dParam0 = settings.reboot_usb ? 0u : (unsigned int)settings.reboot_diagnostic_partition,
-                    .dParam1 = 0,
+                    .dParam0 = settings.reboot_usb ? usb_flags : (unsigned int)settings.reboot_diagnostic_partition,
+                    .dParam1 = (settings.reboot_usb && (settings.led >= 0)) ? settings.led : 0u,
             };
             if (!settings.switch_cpu.empty()) {
                 if (settings.switch_cpu == "arm")
@@ -8675,11 +8687,13 @@ bool reboot_command::execute(device_map &devices) {
             // on RP2040 pass 0 to reboot in to flash
             con.reboot(0, 0, 500);
         } else {
+            uint32_t led_flag = (settings.led >= 0) ? (1u << settings.led) : 0u;
             unsigned int program_base = SRAM_START;
             std::vector<uint32_t> program = {
-                    0x20002100, // movs r0, #0;       movs r1, #0
-                    0x47104a00, // ldr  r2, [pc, #0]; bx r2
-                    bootrom_func_lookup_rp2040(raw_access, rom_table_code('U', 'B'))
+                    0x21004802, // ldr r0, [pc, #8]; movs r1, #0
+                    0x47104a00, // ldr r2, [pc, #0]; bx r2
+                    bootrom_func_lookup_rp2040(raw_access, rom_table_code('U', 'B')),
+                    led_flag,
             };
 
             raw_access.write_vector(program_base, program);

--- a/main.cpp
+++ b/main.cpp
@@ -77,6 +77,11 @@ static __forceinline int __builtin_ctz(unsigned x) {
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
+// preprocessor macros
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+
 #define MAX_REBOOT_TRIES 5
 
 #define OTP_PAGE_COUNT 64
@@ -639,8 +644,15 @@ auto device_selection =
         + option("--rp2040").set(settings.force_rp2040) % "Assume the device is an RP2040 - this is only required when using a custom vid/pid with an RP2040 on Windows, and is ignored on other operating systems"
         + option('f', "--force").set(settings.force) % "Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the command (unless the command itself is a 'reboot') the device will be rebooted back to application mode" +
                 option('F', "--force-no-reboot").set(settings.force_no_reboot) % "Force a device not in BOOTSEL mode but running compatible code to reset so the command can be executed. After executing the command (unless the command itself is a 'reboot') the device will be left connected and accessible to picotool, but without the USB drive mounted"
-        + (option("--led") & integer("led").set(settings.led)) % "Flash LED on this GPIO to show BOOTSEL activity (ignored by Arm RP2350-A2) - only applicable if this command reboots the device to BOOTSEL mode"
-        + option("--active-low").set(settings.active_low) % "The BOOTSEL activity LED is active low (ignored on RP2040 and RP2350-A4)"
+        + (option("--bootsel-led") & integer("gpio").set(settings.led)) % 
+        "Specify the GPIO for the BOOTSEL activity LED to flash (default "
+    #if DEFAULT_BOOTSEL_LED < 0
+        "none"
+    #else
+        STR(DEFAULT_BOOTSEL_LED)
+    #endif
+        ", ignored by RP2350-A2 in Arm mode) - only applicable if this command reboots the device to BOOTSEL mode"
+        + option("--bootsel-led-active-low").set(settings.active_low) % "The BOOTSEL activity LED is active low (ignored by RP2040 and RP2350-A4)"
     ).min(0).doc_non_optional(true).collapse_synopsys("device-selection");
 
 #define file_types_x(i)\

--- a/main.cpp
+++ b/main.cpp
@@ -8659,7 +8659,12 @@ bool reboot_command::execute(device_map &devices) {
         picoboot_memory_access raw_access(con);
         model_t model = raw_access.get_model();
         if (model->supports_picoboot_cmd(PC_REBOOT2)) {
-            uint32_t usb_flags = (settings.led >= 0) ? (settings.active_low ? 0x30u : 0x20u) : 0u;
+            uint32_t usb_flags = 0u;
+            if (settings.led >= 0) {
+                usb_flags |= BOOTSEL_FLAG_GPIO_PIN_SPECIFIED;
+                if (settings.active_low)
+                    usb_flags |= BOOTSEL_FLAG_GPIO_PIN_ACTIVE_LOW;
+            }
             struct picoboot_reboot2_cmd cmd = {
                     .dFlags = (uint8_t)(settings.reboot_usb ? REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL : REBOOT2_FLAG_REBOOT_TYPE_NORMAL),
                     .dDelayMS = 500,


### PR DESCRIPTION
Can use `--led` and `--active-low` arguments with picotool commands that reboot the device to bootsel mode (ie `reboot -u` and forced commands), and can also set default LED with `DEFAULT_BOOTSEL_LED` to always flash that LED even when `--led` isn't passed

Also add a section to BUILDING.md about the various supported CMake variables that can be used to customise the build