### PR TITLE
Fix build errors with gcc 16.1.1

### DIFF
--- a/model/model.h
+++ b/model/model.h
@@ -4,6 +4,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
+
+#ifdef __cplusplus
+#include <algorithm>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#endif
+
 #include "boot/uf2.h"
 #include "boot/picoboot.h"
 
@@ -38,12 +47,6 @@ typedef enum {
 } chip_revision_t;
 
 #ifdef __cplusplus
-
-#include <algorithm>
-#include <memory>
-#include <set>
-#include <string>
-#include <utility>
 #include "addresses.h"
 #include "errors.h"
 


### PR DESCRIPTION
Resolve build failures with gcc 16.1.1 by moving the C++ standard library
includes before the pico-sdk includes so that `__unused` is defined before
it is used.

Without these changes, the build fails with:

    In file included from /home/lars/src/pico-sdk/src/common/boot_picoboot_headers/include/boot/picoboot.h:15,
                    from /home/lars/src/picotool/model/model.h:8,
                    from /home/lars/src/picotool/model/model.cpp:1:
    /usr/include/bits/struct_mutex.h:35:9: error: declaration does not declare anything [-fpermissive]
      35 |   short __unused;
          |         ^~~~~~~~
    In file included from /usr/include/c++/16/x86_64-redhat-linux/bits/gthr-default.h:35,
                    from /usr/include/c++/16/x86_64-redhat-linux/bits/gthr.h:157,
                    from /usr/include/c++/16/ext/atomicity.h:37,
                    from /usr/include/c++/16/bits/shared_ptr_base.h:61,
                    from /usr/include/c++/16/bits/shared_ptr.h:53,
                    from /usr/include/c++/16/memory:82,
                    from /home/lars/src/picotool/model/model.h:43:
    /usr/include/c++/16/ext/concurrence.h:124:34: error: cannot convert ‘<brace-enclosed initializer list>’ to ‘__pthread_internal_list*’ in initialization
      124 |     __gthread_mutex_t _M_mutex = __GTHREAD_MUTEX_INIT;
          |                                  ^~~~~~~~~~~~~~~~~~~~
    /usr/include/c++/16/ext/concurrence.h:179:44: error: cannot convert ‘<brace-enclosed initializer list>’ to ‘__pthread_internal_list*’ in initialization
      179 |     __gthread_recursive_mutex_t _M_mutex = __GTHREAD_RECURSIVE_MUTEX_INIT;
          |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    make[2]: *** [model/CMakeFiles/model.dir/build.make:79: model/CMakeFiles/model.dir/model.cpp.o] Error 1
    make[1]: *** [CMakeFiles/Makefile2:802: model/CMakeFiles/model.dir/all] Error 2
    make: *** [Makefile:136: all] Error 2

Signed-off-by: Lars Kellogg-Stedman <lars@oddbit.com>
