### PR TITLE
Reduce default-pt partition sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,7 +874,8 @@ PARTITION CREATE:
 
 SYNOPSIS:
     picotool partition create [--quiet] [--verbose] <infile> <outfile> [-t <type>] [[-o <offset>] [--family <family_id>]] [<bootloader>] [-t
-                <type>] [[--sign <keyfile>] [-t <type>] [--no-hash] [--singleton]] [[--abs-block] [<abs_block_loc>]]
+                <type>] [[--sign <keyfile>] [-t <type>] [--no-hash] [--singleton] [--no-btstack-flash-bank]] [[--abs-block]
+                [<abs_block_loc>]]
 
 OPTIONS:
         --quiet
@@ -911,6 +912,8 @@ OPTIONS:
             Don't hash the partition table
         --singleton
             Singleton partition table
+        --no-btstack-flash-bank
+            Don't check for compatibility with BTStack flash bank
     Errata RP2350-E10 Fix
         --abs-block
             Enforce support for an absolute block

--- a/json/default-pt.json
+++ b/json/default-pt.json
@@ -13,7 +13,7 @@
         {
             "name": "A",
             "id": 0,
-            "size": "2044K",
+            "size": "2036K",
             "families": ["rp2350-arm-s", "rp2350-riscv"],
             "permissions": {
                 "secure": "rw",
@@ -24,7 +24,7 @@
         {
             "name": "B",
             "id": 1,
-            "size": "2044K",
+            "size": "2036K",
             "families": ["rp2350-arm-s", "rp2350-riscv"],
             "permissions": {
                 "secure": "rw",

--- a/main.cpp
+++ b/main.cpp
@@ -6621,6 +6621,17 @@ uint32_t families_to_flags(std::vector<string> families, bool fail_invalid = fal
     return ret;
 }
 
+uint32_t round_up_power_2(uint32_t v) {
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    v++;
+    return v;
+}
+
 bool partition_create_command::execute(device_map &devices) {
     if (get_file_type_idx(0) != filetype::json) {
         fail(ERROR_ARGS, "json must be a json file\n");
@@ -6759,6 +6770,31 @@ bool partition_create_command::execute(device_map &devices) {
             }  
         }
         pt.partitions.push_back(new_p);
+    }
+
+    // Catch partition tables which cover the end of Flash, which the SDK uses for the BTStack flash bank
+    uint num_end_sectors = 2; // for BTStack flash bank
+#if SUPPORT_RP2350_A2
+    bool abs_block_at_end = false;
+    if (settings.uf2.abs_block_loc) {
+        uint32_t abs_block_flash_loc = settings.uf2.abs_block_loc - FLASH_START;
+        if (round_up_power_2(abs_block_flash_loc) <= abs_block_flash_loc + 0x1000) {
+            // if abs_block within 4k of end, also keep space for that
+            num_end_sectors++;
+            abs_block_at_end = true;
+        }
+    }
+#endif
+
+    if (round_up_power_2(cur_pos) - cur_pos < num_end_sectors) {
+        // Likely this partition table doesn't account for BTStack flash bank at end
+        fos << "WARNING: This partition table covers the last " << num_end_sectors;
+        fos << " Flash sectors for flash size " << round_up_power_2(cur_pos) / (1024/4);
+        fos << "M, which will interfere with the BTStack flash bank";
+    #if SUPPORT_RP2350_A2
+        if (abs_block_at_end) fos << ", and the RP2350-E10 absolute block,";
+    #endif
+        fos << " if that is the actual flash size\n";
     }
 
     pt_block->items.push_back(std::make_shared<partition_table_item>(pt));

--- a/main.cpp
+++ b/main.cpp
@@ -6680,6 +6680,7 @@ bool partition_create_command::execute(device_map &devices) {
 #endif
 
     uint32_t cur_pos = 2;
+    uint32_t max_pos = 0;
 
     for (auto p : partitions) {
         partition_table_item::partition new_p;
@@ -6690,13 +6691,14 @@ bool partition_create_command::execute(device_map &devices) {
         if (start >= 4096 || size >= 4096) {
             if (start == cur_pos) start *= 0x1000;
             if (start % 0x1000 || size % 0x1000) {
-                fail(ERROR_INCOMPATIBLE, "Partition table start (%dK) and size (%dK) must be 4K aligned", start/1024, size/1024);
+                fail(ERROR_INCOMPATIBLE, "Partition start (%dK) and size (%dK) must be 4K aligned", start/1024, size/1024);
             }
             start /= 0x1000;
             size /= 0x1000;
         }
 
         cur_pos = start + size;
+        if (cur_pos > max_pos) max_pos = cur_pos;
     #if SUPPORT_RP2350_A2
         if (start <= (settings.uf2.abs_block_loc - FLASH_START)/0x1000 && start + size > (settings.uf2.abs_block_loc - FLASH_START)/0x1000) {
             fail(ERROR_INCOMPATIBLE, "The address %" PRIx32 " cannot be in a partition for the RP2350-E10 fix to work", settings.uf2.abs_block_loc);
@@ -6786,10 +6788,10 @@ bool partition_create_command::execute(device_map &devices) {
     }
 #endif
 
-    if (round_up_power_2(cur_pos) - cur_pos < num_end_sectors) {
+    if (round_up_power_2(max_pos) - max_pos < num_end_sectors) {
         // Likely this partition table doesn't account for BTStack flash bank at end
         fos << "WARNING: This partition table covers the last " << num_end_sectors;
-        fos << " Flash sectors for flash size " << round_up_power_2(cur_pos) / (1024/4);
+        fos << " Flash sectors for flash size " << round_up_power_2(max_pos) / (1024/4);
         fos << "M, which will interfere with the BTStack flash bank";
     #if SUPPORT_RP2350_A2
         if (abs_block_at_end) fos << ", and the RP2350-E10 absolute block,";

--- a/main.cpp
+++ b/main.cpp
@@ -634,6 +634,7 @@ struct _settings {
         #endif
         bool sign = false;
         bool singleton = false;
+        bool no_btstack_flash_bank = false;
     } partition;
 
     struct {
@@ -1114,7 +1115,8 @@ struct partition_create_command : public cmd {
                     named_file_types_x("pem", 3)) % "Sign the partition table" + 
                     (option("--no-hash").clear(settings.partition.hash) % "Don't hash the partition table") + 
                 #endif
-                    (option("--singleton").set(settings.partition.singleton) % "Singleton partition table")
+                    (option("--singleton").set(settings.partition.singleton) % "Singleton partition table") +
+                    (option("--no-btstack-flash-bank").set(settings.partition.no_btstack_flash_bank) % "Don't check for compatibility with BTStack flash bank")
                 ).min(0).force_expand_help(true) % "Partition Table Options"
             #if SUPPORT_RP2350_A2
                 + (
@@ -6775,15 +6777,20 @@ bool partition_create_command::execute(device_map &devices) {
     }
 
     // Catch partition tables which cover the end of Flash, which the SDK uses for the BTStack flash bank
-    uint num_end_sectors = 2; // for BTStack flash bank
+    uint num_end_sectors = 0;
+    string end_sectors_warning_output = "";
+    if (!settings.partition.no_btstack_flash_bank) {
+        num_end_sectors += 2; // for BTStack flash bank
+        end_sectors_warning_output += "the BTStack flash bank";
+    }
 #if SUPPORT_RP2350_A2
-    bool abs_block_at_end = false;
     if (settings.uf2.abs_block_loc) {
         uint32_t abs_block_flash_loc = settings.uf2.abs_block_loc - FLASH_START;
         if (round_up_power_2(abs_block_flash_loc) <= abs_block_flash_loc + 0x1000) {
             // if abs_block within 4k of end, also keep space for that
-            num_end_sectors++;
-            abs_block_at_end = true;
+            num_end_sectors += 1;
+            if (!end_sectors_warning_output.empty()) end_sectors_warning_output += ", and ";
+            end_sectors_warning_output += "the RP2350-E10 absolute block";
         }
     }
 #endif
@@ -6792,10 +6799,8 @@ bool partition_create_command::execute(device_map &devices) {
         // Likely this partition table doesn't account for BTStack flash bank at end
         fos << "WARNING: This partition table covers the last " << num_end_sectors;
         fos << " Flash sectors for flash size " << round_up_power_2(max_pos) / (1024/4);
-        fos << "M, which will interfere with the BTStack flash bank";
-    #if SUPPORT_RP2350_A2
-        if (abs_block_at_end) fos << ", and the RP2350-E10 absolute block,";
-    #endif
+        fos << "M, which will interfere with ";
+        fos << end_sectors_warning_output;
         fos << " if that is the actual flash size\n";
     }
 


### PR DESCRIPTION
Needs 3 * 4K at the end for BT flash bank and E10 abs block, in addition to the existing 2 * 4K at the start for PT slots

Also adds a warning to `picotool partition create` when this space isn't free, which will print like this - a bit wordy, happy to reduce the wordiness if there are suggestions
```
WARNING: This partition table covers the last 2 Flash sectors for flash size 4M, which will interfere with the BTStack flash bank if that is the actual flash size
```
or
```
WARNING: This partition table covers the last 3 Flash sectors for flash size 4M, which will interfere with the BTStack flash bank, and the RP2350-E10 absolute block, if that is the actual flash size
```