### PR TITLE
Add warning for boards missing bootsel resistor

### DIFF
--- a/bintool/bintool.cpp
+++ b/bintool/bintool.cpp
@@ -920,11 +920,10 @@ std::vector<uint8_t> hash_andor_sign(std::vector<uint8_t> bin, uint32_t storage_
 
 
 void verify_block(std::vector<uint8_t> bin, uint32_t storage_addr, uint32_t runtime_addr, block *block, model_t model, verified_t &hash_verified, verified_t &sig_verified, get_more_bin_cb more_cb) {
-    std::shared_ptr<load_map_item> load_map = block->get_item<load_map_item>();
     std::shared_ptr<hash_def_item> hash_def = block->get_item<hash_def_item>();
     hash_verified = none;
     sig_verified = none;
-    if (load_map == nullptr || hash_def == nullptr) {
+    if (hash_def == nullptr) {
         return;
     }
     std::vector<uint8_t> to_hash = get_lm_hash_data(bin, storage_addr, runtime_addr, block, more_cb, model);

--- a/main.cpp
+++ b/main.cpp
@@ -3416,12 +3416,16 @@ static chip_t image_type_exe_chip_to_chip(uint image_type_exe_chip) {
 }
 
 #if HAS_LIBUSB
-void info_guts(memory_access &raw_access, picoboot::connection *con) {
+void info_guts(memory_access &raw_access, picoboot::connection *con, bool no_pt_loaded=false) {
+    model_t model = raw_access.get_model();
 #else
-void info_guts(memory_access &raw_access, void *con) {
+void info_guts(memory_access &raw_access, void *con, bool no_pt_loaded=false) {
 #endif
     // Use flash caching
     settings.use_flash_cache = true;
+    // Track if a valid partition table was found in the block loop
+    bool has_valid_pt = false;
+    bool has_invalid_pt = false;
     // Callback to pass to bintool, to get more bin data
     get_more_bin_cb more_cb = [&raw_access](std::vector<uint8_t> &bin, uint32_t offset, uint32_t size) {
         DEBUG_LOG("Now reading from %x size %x\n", offset, size);
@@ -3459,6 +3463,7 @@ void info_guts(memory_access &raw_access, void *con) {
             }
         };
         auto info_metadata = [&](block *current_block, bool verbose_metadata = false) {
+            bool is_pt = false;
             verified_t hash_verified = none;
             verified_t sig_verified = none;
         #if HAS_MBEDTLS
@@ -3514,6 +3519,8 @@ void info_guts(memory_access &raw_access, void *con) {
             // Partition Table
             auto partition_table = current_block->get_item<partition_table_item>();
             if (partition_table != nullptr) {
+                is_pt = true; // this block is a partition table
+                has_valid_pt = true; // assume it is valid - hash and sig checks will invalidate it if not
                 if (verbose_metadata) info_pair("block type", "partition table");
                 info_pair("partition table", partition_table->singleton ? "singleton" : "non-singleton");
                 std::stringstream unpartitioned;
@@ -3642,6 +3649,10 @@ void info_guts(memory_access &raw_access, void *con) {
                     }
                     info_pair("hash value", val.str());
                 }
+                if (is_pt && hash_verified != passed) {
+                    has_valid_pt = false; // partition table has bad hash
+                    has_invalid_pt = true;
+                }
             }
             if (sig_verified != none) {
                 info_pair("signature", sig_verified == passed ? "verified" : "incorrect");
@@ -3658,6 +3669,10 @@ void info_guts(memory_access &raw_access, void *con) {
                         pkey << hex_string(i, 2, false, true);
                     }
                     info_pair("public key", pkey.str());
+                }
+                if (is_pt && sig_verified != passed) {
+                    has_valid_pt = false; // partition table has bad signature
+                    has_invalid_pt = true;
                 }
             }
         };
@@ -3879,7 +3894,6 @@ void info_guts(memory_access &raw_access, void *con) {
         std::vector<std::pair<string,string>> device_state_pairs;
         if ((settings.info.show_device || settings.info.all) && raw_access.is_device()) {
             select_group(device_info);
-            model_t model = raw_access.get_model();
             uint8_t rom_version;
             raw_access.read_raw(0x13, rom_version);
             info_pair("type", model->name());
@@ -4063,6 +4077,24 @@ void info_guts(memory_access &raw_access, void *con) {
     } catch (not_mapped_exception&e) {
         std::cout << "\nfailed to read memory at " << hex_string(e.addr) << "\n";
     }
+
+#if HAS_LIBUSB
+    if (no_pt_loaded && model->chip() != rp2040) {
+        if (has_valid_pt) {
+            fos.first_column(0); fos.hanging_indent(0);
+            fos << "\nWARNING: Device has no partition table loaded, but has a partition table at the start of flash.\n";
+            fos.first_column(sizeof("WARNING: ") - 1);
+            fos << "This may cause picotool to behave unpredictably.\n";
+            fos << "This could be due to using a custom board which is missing the resistor inline with the BOOTSEL button, ";
+            fos << "or if BOOT_FLAGS0.HASHED_PARTITION_TABLE or BOOT_FLAGS0.SECURE_PARTITION_TABLE is set in OTP and the partition table is not hashed/signed\n";
+        } else if (has_invalid_pt) {
+            fos.first_column(0); fos.hanging_indent(0);
+            fos << "\nWARNING: Device has no partition table loaded, but has an incorrectly hashed/signed partition table at the start of flash.\n";
+            fos.first_column(sizeof("WARNING: ") - 1);
+            fos << "This may cause picotool to behave unpredictably.\n";
+        }
+    }
+#endif
 }
 
 void config_guts(memory_access &raw_access) {
@@ -4545,7 +4577,7 @@ bool info_command::execute(device_map &devices) {
                     info_guts(access, &connection);
                 }
             } else {
-                info_guts(access, &connection);
+                info_guts(access, &connection, true);
             }
         }
     } else {

--- a/main.cpp
+++ b/main.cpp
@@ -4089,7 +4089,7 @@ void info_guts(memory_access &raw_access, void *con, bool no_pt_loaded=false) {
             fos << "or if BOOT_FLAGS0.HASHED_PARTITION_TABLE or BOOT_FLAGS0.SECURE_PARTITION_TABLE is set in OTP and the partition table is not hashed/signed\n";
         } else if (has_invalid_pt) {
             fos.first_column(0); fos.hanging_indent(0);
-            fos << "\nWARNING: Device has no partition table loaded, but has an incorrectly hashed/signed partition table at the start of flash.\n";
+            fos << "\nWARNING: Device has an incorrectly hashed/signed partition table at the start of flash.\n";
             fos.first_column(sizeof("WARNING: ") - 1);
             fos << "This may cause picotool to behave unpredictably.\n";
         }

--- a/main.cpp
+++ b/main.cpp
@@ -3424,8 +3424,8 @@ void info_guts(memory_access &raw_access, void *con, bool no_pt_loaded=false) {
     // Use flash caching
     settings.use_flash_cache = true;
     // Track if a valid partition table was found in the block loop
-    bool has_valid_pt = false;
-    bool has_invalid_pt = false;
+    bool has_pt = false;
+    bool pt_is_valid = true;
     // Callback to pass to bintool, to get more bin data
     get_more_bin_cb more_cb = [&raw_access](std::vector<uint8_t> &bin, uint32_t offset, uint32_t size) {
         DEBUG_LOG("Now reading from %x size %x\n", offset, size);
@@ -3520,7 +3520,7 @@ void info_guts(memory_access &raw_access, void *con, bool no_pt_loaded=false) {
             auto partition_table = current_block->get_item<partition_table_item>();
             if (partition_table != nullptr) {
                 is_pt = true; // this block is a partition table
-                has_valid_pt = true; // assume it is valid - hash and sig checks will invalidate it if not
+                has_pt = true; // assume it is valid - hash and sig checks will invalidate it if not
                 if (verbose_metadata) info_pair("block type", "partition table");
                 info_pair("partition table", partition_table->singleton ? "singleton" : "non-singleton");
                 std::stringstream unpartitioned;
@@ -3650,8 +3650,7 @@ void info_guts(memory_access &raw_access, void *con, bool no_pt_loaded=false) {
                     info_pair("hash value", val.str());
                 }
                 if (is_pt && hash_verified != passed) {
-                    has_valid_pt = false; // partition table has bad hash
-                    has_invalid_pt = true;
+                    pt_is_valid = false; // partition table has bad hash
                 }
             }
             if (sig_verified != none) {
@@ -3671,8 +3670,7 @@ void info_guts(memory_access &raw_access, void *con, bool no_pt_loaded=false) {
                     info_pair("public key", pkey.str());
                 }
                 if (is_pt && sig_verified != passed) {
-                    has_valid_pt = false; // partition table has bad signature
-                    has_invalid_pt = true;
+                    pt_is_valid = false; // partition table has bad signature
                 }
             }
         };
@@ -4080,14 +4078,14 @@ void info_guts(memory_access &raw_access, void *con, bool no_pt_loaded=false) {
 
 #if HAS_LIBUSB
     if (no_pt_loaded && model->chip() != rp2040) {
-        if (has_valid_pt) {
+        if (has_pt && pt_is_valid) {
             fos.first_column(0); fos.hanging_indent(0);
             fos << "\nWARNING: Device has no partition table loaded, but has a partition table at the start of flash.\n";
             fos.first_column(sizeof("WARNING: ") - 1);
             fos << "This may cause picotool to behave unpredictably.\n";
             fos << "This could be due to using a custom board which is missing the resistor in series with the BOOTSEL button, ";
             fos << "or if BOOT_FLAGS0.HASHED_PARTITION_TABLE or BOOT_FLAGS0.SECURE_PARTITION_TABLE is set in OTP and the partition table is not hashed/signed\n";
-        } else if (has_invalid_pt) {
+        } else if (has_pt && (!pt_is_valid)) {
             fos.first_column(0); fos.hanging_indent(0);
             fos << "\nWARNING: Device has an incorrectly hashed/signed partition table at the start of flash.\n";
             fos.first_column(sizeof("WARNING: ") - 1);

--- a/main.cpp
+++ b/main.cpp
@@ -4085,7 +4085,7 @@ void info_guts(memory_access &raw_access, void *con, bool no_pt_loaded=false) {
             fos << "\nWARNING: Device has no partition table loaded, but has a partition table at the start of flash.\n";
             fos.first_column(sizeof("WARNING: ") - 1);
             fos << "This may cause picotool to behave unpredictably.\n";
-            fos << "This could be due to using a custom board which is missing the resistor inline with the BOOTSEL button, ";
+            fos << "This could be due to using a custom board which is missing the resistor in series with the BOOTSEL button, ";
             fos << "or if BOOT_FLAGS0.HASHED_PARTITION_TABLE or BOOT_FLAGS0.SECURE_PARTITION_TABLE is set in OTP and the partition table is not hashed/signed\n";
         } else if (has_invalid_pt) {
             fos.first_column(0); fos.hanging_indent(0);

--- a/main.cpp
+++ b/main.cpp
@@ -4077,15 +4077,15 @@ void info_guts(memory_access &raw_access, void *con, bool no_pt_loaded=false) {
     }
 
 #if HAS_LIBUSB
-    if (no_pt_loaded && model->chip() != rp2040) {
-        if (has_pt && pt_is_valid) {
+    if (has_pt && no_pt_loaded && model->chip() != rp2040) {
+        if (pt_is_valid) {
             fos.first_column(0); fos.hanging_indent(0);
             fos << "\nWARNING: Device has no partition table loaded, but has a partition table at the start of flash.\n";
             fos.first_column(sizeof("WARNING: ") - 1);
             fos << "This may cause picotool to behave unpredictably.\n";
             fos << "This could be due to using a custom board which is missing the resistor in series with the BOOTSEL button, ";
             fos << "or if BOOT_FLAGS0.HASHED_PARTITION_TABLE or BOOT_FLAGS0.SECURE_PARTITION_TABLE is set in OTP and the partition table is not hashed/signed\n";
-        } else if (has_pt && (!pt_is_valid)) {
+        } else {
             fos.first_column(0); fos.hanging_indent(0);
             fos << "\nWARNING: Device has an incorrectly hashed/signed partition table at the start of flash.\n";
             fos.first_column(sizeof("WARNING: ") - 1);


### PR DESCRIPTION
This adds a warning to `picotool info` which gets printed when no partition table was loaded at boot, but a partition table is present in Flash:

```
WARNING: Device has no partition table loaded, but has a partition table at the start of flash.
         This may cause picotool to behave unpredictably.
         This could be due to using a custom board which is missing the resistor inline with the BOOTSEL button, or if
         BOOT_FLAGS0.HASHED_PARTITION_TABLE or BOOT_FLAGS0.SECURE_PARTITION_TABLE is set in OTP and the partition table is not hashed/signed
```

The cause for this that prompted this PR was a board missing the resistor inline with the BOOTSEL button, which meant CS stays low while the button is held, so the bootrom reads 0s from flash when booting up rather than reading the partition table. According to the hardware team, this can be a common issue with custom boards. Once the button is released, the partition table can then be read by `picotool info`.

This can also occur if you have an unhashed/unsigned PT with `BOOT_FLAGS0.HASHED_PARTITION_TABLE` or `BOOT_FLAGS0.SECURE_PARTITION_TABLE` set in OTP, hence adding those to the warning message.

Also fixes hash/sig verification for partition tables, and prints a warning when an incorrectly hashed/signed PT is found at the start of flash:

```
WARNING: Device has no partition table loaded, but has an incorrectly hashed/signed partition table at the start of flash.
         This may cause picotool to behave unpredictably.
```

Note that this warning does not occur when the partition table has been modified since load - that still throws the immediate error:
```
ERROR: The RP2350 device returned an error: modified data (pt modified since load)
```

The main unpredictable behaviour I'm referring to is the fact that `picotool partition info` says `there is no partition table` but `picotool info` prints the details of the partition table. `picotool` will also treat a device in this state as if it has no partition table, so will overwrite the partition table with `picotool load` rather than loading into a partition.