### PR TITLE
Add missing include

### DIFF
--- a/cli.h
+++ b/cli.h
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <limits>
 #include <cstdint>
+#include <iterator>
 
 /**
  * Note this is a hastily hacked together command line parser.


### PR DESCRIPTION
`cli.h` uses `std::back_inserter` which is defined in `<iterator>`.