### PR TITLE
Possible fix for #300

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,10 @@ target_compile_definitions(picotool PRIVATE
         SUPPORT_RP2350_A2=1
         CODE_OTP=${PICOTOOL_CODE_OTP}
         )
+# Just GCC 15.1 I think, but harmless on other versions
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_definitions(picotool PRIVATE _GTHREAD_USE_COND_INIT_FUNC)
+endif()
 # for OTP info
 target_include_directories(picotool PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(picotool

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -5,6 +5,11 @@ target_include_directories(model PUBLIC ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURREN
 
 target_link_libraries(model PUBLIC boot_uf2_headers boot_picoboot_headers pico_platform_headers errors)
 
+# Just GCC 15.1 I think, but harmless on other versions
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_definitions(model PRIVATE _GTHREAD_USE_COND_INIT_FUNC)
+endif()
+
 add_custom_target(unreadable_rom_data DEPENDS
         ${CMAKE_CURRENT_BINARY_DIR}/rp2350_a2_rom_end.h
         ${CMAKE_CURRENT_BINARY_DIR}/rp2350_a3_rom_end.h


### PR DESCRIPTION
Copied from the SDK fix to pioasm (https://github.com/raspberrypi/pico-sdk/pull/3032) - not sure if there are any other libraries where this needs to be defined (picotool uses static libraries for speedier compilation, so the compile definition needs adding to any affected library)