### PR TITLE
main: fix `picotool info` for non-partition-capable devices

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4670,7 +4670,8 @@ std::shared_ptr<tuple<resident_partition_t, std::shared_ptr<vector<partition_det
 }
 
 std::shared_ptr<vector<partition_details>> get_partitions(picoboot::connection &con) {
-    return std::get<1>(*get_partition_info(con));
+    auto pi = get_partition_info(con);
+    return pi ? std::get<1>(*pi) : nullptr;
 }
 #endif
 


### PR DESCRIPTION
Fixes #336.
