### PR TITLE
Copy pull request template from pico-sdk

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+_Instructions: (please delete)_
+ - _please do not submit against `master`, use `develop` instead_
+ - _please make sure there is an associated issue for your PR, and reference it via "Fixes #num" in the description_
+ - _please enter a detailed description_


### PR DESCRIPTION
We can't change the default branch, but this should make it clearer that you should submit against `develop` as requested in https://github.com/raspberrypi/picotool/pull/338#issuecomment-4932615417