### PR TITLE
Fix warnings in Clang build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/*
+build-*
 bazel-*
 
 # Ignore until https://github.com/bazelbuild/bazel/issues/20369 is fixed.

--- a/lib/oofatfs/CMakeLists.txt
+++ b/lib/oofatfs/CMakeLists.txt
@@ -7,7 +7,7 @@ target_sources(fatfs INTERFACE
 target_include_directories(fatfs INTERFACE ${CMAKE_CURRENT_LIST_DIR}/src)
 
 function(suppress_oofatfs_warnings)
-        if (NOT MSVC)
+        if (NOT (MSVC OR (${CMAKE_C_COMPILER_ID} MATCHES "Clang")))
                 set_source_files_properties(
                         # To work around lack of support for ${CMAKE_CURRENT_FUNCTION_LIST_DIR} in CMake <3.17
                         ${CMAKE_SOURCE_DIR}/lib/oofatfs/src/ff.c

--- a/main.cpp
+++ b/main.cpp
@@ -224,7 +224,7 @@ std::array<std::array<string, 48>, 12> pin_functions_rp2350{{
     {"",        "",         "UART0 TX", "UART0 RX", "",         "",         "UART1 TX", "UART1 RX", "",         "",         "UART1 TX", "UART1 RX", "",         "",         "UART0 TX", "UART0 RX", "",         "",         "UART0 TX", "UART0 RX", "",         "",         "UART1 TX", "UART1 RX", "",         "",         "UART1 TX", "UART1 RX", "",         "",         "UART0 TX", "UART0 RX", "",         "",         "UART0 TX", "UART0 RX", "",         "",         "UART1 TX", "UART1 RX", "",         "",         "UART1 TX", "UART1 RX", "",         "",         "UART0 TX", "UART0 RX"}
 }};
 
-static_assert(pin_functions_unknown.size() >= std::max(pin_functions_rp2040.size(), pin_functions_rp2350.size()));
+static_assert(pin_functions_unknown.size() >= std::max(pin_functions_rp2040.size(), pin_functions_rp2350.size()), "pin_functions_unknown size is too small");
 
 std::map<uint32_t, otp_reg> otp_regs;
 


### PR DESCRIPTION
Fixes these warnings in Clang build:
```
warning: unknown warning option '-Wno-stringop-overflow'; did you mean '-Wno-shift-overflow'?
      [-Wunknown-warning-option]
[ 99%] Building C object CMakeFiles/picotool.dir/lib/littlefs/lfs_util.c.o
1 warning generated.
picotool/main.cpp:227:113: warning: 'static_assert' with no message is a C++17 extension
      [-Wc++17-extensions]
  227 | static_assert(pin_functions_unknown.size() >= std::max(pin_functions_rp2040.size(), pin_functions_rp2350.size()));
      |                                                                                                                 ^
```

Also add build-* to .gitignore