### PR TITLE
Get model from family, if '--platform' is missing

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4558,10 +4558,17 @@ uint32_t get_family_id(uint8_t file_idx) {
 }
 
 model_t get_model(uint8_t file_idx) {
-    model_t model;
+    model_t model = nullptr;
     if (settings.model) {
         model = settings.model;
-    } else {
+    } else if (settings.family_id) {
+        auto model_f = model_from_family(settings.family_id);
+        if (model_f->chip() != unknown) {
+            settings.model = model_f;
+            model = settings.model;
+        }
+    }
+    if (model == nullptr) {
         auto file_access = get_file_memory_access(file_idx);
         model = get_access_model(file_access);
     }

--- a/main.cpp
+++ b/main.cpp
@@ -4562,10 +4562,9 @@ model_t get_model(uint8_t file_idx) {
     if (settings.model) {
         model = settings.model;
     } else if (settings.family_id) {
-        auto model_f = model_from_family(settings.family_id);
-        if (model_f->chip() != unknown) {
-            settings.model = model_f;
-            model = settings.model;
+        auto model_guess = model_from_family(settings.family_id);
+        if (model_guess->chip() != unknown) {
+            model = model_guess;
         }
     }
     if (model == nullptr) {


### PR DESCRIPTION
If the user does not use the `--platform` parameter to specify the target platform for uf2 convert command, get the model from the target family. The current logic tries to guess the platform by analyzing the target binary file. It works OK in most regular cases, but fails in some weird cases where the image is not located at absolute FLASH_START offset.

fixes #339 
