### PR TITLE
[Bazel] Remove implicit `__init__.py` creation

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -14,9 +14,11 @@ cc_library(
 py_binary(
     name = "binh",
     srcs = ["binh.py"],
+    legacy_create_init = False,
 )
 
 py_binary(
     name = "jsonh",
     srcs = ["jsonh.py"],
+    legacy_create_init = False,
 )


### PR DESCRIPTION
The `py_binary` targets use implicit `__init__.py` creation, which on the latest `rules_python`, causes considerable warning spam:
```bash
DEBUG: /private/var/tmp/_bazel_user/86369c54f74076c704937def07bebfcf/external/rules_python+/python/private/py_executable.bzl:1498:14: 
======================================================================
WARNING: Target @@picotool+//bazel:jsonh is using implicit __init__.py creation.
  This diabolic behavior is deprecated and will be disabled by default in a
  future release.
  See https://github.com/bazel-contrib/rules_python/issues/2945

  Ensure all __init__.py files are explicitly created and
  added to the srcs or deps of your targets.

  Disable implicit creation by setting:
    legacy_create_init = 0
  on the target, or globally by setting:
    --incompatible_default_to_explicit_init_py
======================================================================
```

These flags silence the warning, although I'm not totally certain why it appeared at all. These are standalone scripts that only import from the stdlib.