### PR TITLE
Update gen_help_txt.sh to early-exit if picotool command is missing

### DIFF
--- a/gen_help_txt.sh
+++ b/gen_help_txt.sh
@@ -2,6 +2,11 @@
 
 ALLOWED_MISSING_COMMANDS="version"
 
+if ! command -v picotool; then
+    echo "Failing job due to picotool command not being in the PATH"
+    exit 1
+fi
+
 mkdir -p tmp
 cp README.md tmp/README.md
 


### PR DESCRIPTION
If the `picotool` command **is** missing, then running the current version of `gen_help_txt.sh` deletes about half of the `README.md` contents!