### PR TITLE
Fix two outdated facts in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,7 +8,7 @@ git submodule update --init lib/mbedtls
 
 You also need to install `libusb-1.0` if you want to use the USB functionality.
 
-> If libusb-1.0 is not installed, picotool still builds, but it omits all options that deal with managing a pico via USB (load, save, erase, verify, reboot). Builds that do not include USB support can be identified by running `picotool version`, which will state `This version of picotool was compiled without USB support. Some commands are not available.`. Additionally, the unsupported commands won't appear in the output of the help command, and if you attempt to execute an invalid command you will get an error message. The build output message `libUSB is not found - no USB support will be built` also appears in the build logs.
+> If libusb-1.0 is not installed, picotool still builds, but it omits all options that deal with managing a pico via USB (load, save, erase, verify, reboot, bdev). Builds that do not include USB support can be identified by running `picotool version`, which will state `This version of picotool was compiled without USB support. Some commands are not available.`. Additionally, the unsupported commands won't appear in the output of the help command, and if you attempt to execute an invalid command you will get an error message. The build output message `libUSB is not found - no USB support will be built` also appears in the build logs.
 
 ### Linux / macOS
 
@@ -103,7 +103,7 @@ In order for the SDK to find `picotool` in this custom folder, you will usually 
 
 The `picotool` build has some CMake variables you can use to customise how the build works, and how `picotool` functions:
 
-- `GENERATE_FIXED_DOCS_WIDTH`: By default the width of the output from `picotool` adjusts to the width of the terminal. Setting this to `true` fixes the width to 140, which is used when generating the [README](README.md).
+- `GENERATE_FIXED_DOCS_WIDTH`: By default the width of the output from `picotool` adjusts to the width of the terminal. Setting this to `true` fixes the width to 95, which is used when generating the [README](README.md).
 - `DEFAULT_BOOTSEL_LED`: This can be used to set the default value for the `--bootsel-led` argument, so `picotool` always reboots devices to BOOTSEL with that LED used as the activity indicator.
 - `PICOTOOL_NO_LIBUSB`: By default `picotool` is compiled with USB support if libusb is found. Setting this to `true` explicitly compiles without USB support, which is used when the Pico SDK builds picotool.
 - `USE_PRECOMPILED`: By default the build uses pre-compiled ELF/BIN files for code that is run on the device (enc_bootloader, xip_ram_perms, and picoboot_flash_id). Setting this to `false` re-compiles these files instead.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,7 +8,7 @@ git submodule update --init lib/mbedtls
 
 You also need to install `libusb-1.0` if you want to use the USB functionality.
 
-> If libusb-1.0 is not installed, picotool still builds, but it omits all options that deal with managing a pico via USB (load, save, erase, verify, reboot, bdev). Builds that do not include USB support can be identified by running `picotool version`, which will state `This version of picotool was compiled without USB support. Some commands are not available.`. Additionally, the unsupported commands won't appear in the output of the help command, and if you attempt to execute an invalid command you will get an error message. The build output message `libUSB is not found - no USB support will be built` also appears in the build logs.
+> If libusb-1.0 is not installed, picotool still builds, but it omits all options that deal with managing a pico via USB (load, save, reboot, etc.). Builds that do not include USB support can be identified by running `picotool version`, which will state `This version of picotool was compiled without USB support. Some commands are not available.`. Additionally, the unsupported commands won't appear in the output of the help command, and if you attempt to execute an invalid command you will get an error message. The build output message `libUSB is not found - no USB support will be built` also appears in the build logs.
 
 ### Linux / macOS
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,7 +8,7 @@ git submodule update --init lib/mbedtls
 
 You also need to install `libusb-1.0` if you want to use the USB functionality.
 
-> If libusb-1.0 is not installed, picotool still builds, but it omits all options that deal with managing a pico via USB (load, save, reboot, etc.). Builds that do not include USB support can be identified by running `picotool version`, which will state `This version of picotool was compiled without USB support. Some commands are not available.`. Additionally, the unsupported commands won't appear in the output of the help command, and if you attempt to execute an invalid command you will get an error message. The build output message `libUSB is not found - no USB support will be built` also appears in the build logs.
+> If libusb-1.0 is not installed, picotool still builds, but it omits all options that deal with managing a Pico via USB (load, save, reboot, etc.). Builds that do not include USB support can be identified by running `picotool version`, which will state `This version of picotool was compiled without USB support. Some commands are not available.`. Additionally, the unsupported commands won't appear in the output of the help command, and if you attempt to execute an invalid command you will get an error message. The build output message `libUSB is not found - no USB support will be built` also appears in the build logs.
 
 ### Linux / macOS
 

--- a/README.md
+++ b/README.md
@@ -1568,8 +1568,8 @@ OPTIONS:
 ```
 
 ```text
-$ picotool otp permissions --sign private.pem --tx 46 sample-permissions.json 
-Picking file ./xip_ram_perms.elf
+$ picotool otp permissions --sign private.pem sample-permissions.json 
+Picking file /usr/local/share/picotool/xip_ram_perms.elf
 page10
 page10 = 0
 setting page10 -> 4063233
@@ -1578,11 +1578,8 @@ page11 = 0
 setting page11 -> 4128781
 page12
 page12 = 0
-setting page12 -> 4128781
-tx_pin = 0
-setting tx_pin -> 46
+setting page12 -> 4128768
 Loading into XIP RAM: [==============================]  100%
->>> using flash update boot of 13ffc000
 
 The device was rebooted to start the application.
 ```


### PR DESCRIPTION
`CMakeLists.txt` compiles `DOCS_WIDTH=95`; BUILDING.md still says 140. #334 changed it deliberately ("Reduce command width in the README"), a month after that sentence was last touched.

Without libusb six commands go, not five: `bdev` is missing.

Not fixed: the README `otp permissions` example passes `--tx`, which is not an option: the only `--tx` in any tracked C/C++ source, ever, is the `--tx_remaining` decrement in flash_id.c. That block also has device output I can't regenerate.